### PR TITLE
init: font 및 theme을 세팅합니다.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link
+      rel="stylesheet"
+      as="style"
+      crossorigin
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
   </head>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,8 @@ import { RouterProvider } from "react-router-dom";
 import { router } from "./Router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import theme from "./styles/theme";
+import { ThemeProvider } from "@emotion/react";
 
 function App() {
   const queryClient = new QueryClient({
@@ -17,8 +19,10 @@ function App() {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-      <ReactQueryDevtools />
+      <ThemeProvider theme={theme}>
+        <RouterProvider router={router} />
+        <ReactQueryDevtools />
+      </ThemeProvider>
     </QueryClientProvider>
   );
 }

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -173,7 +173,9 @@ const resetCss = css`
 const gStyle = css`
   ${resetCss}
 
-  #root, body, html {
+  #root,
+  body,
+  html {
     margin: 0 auto;
 
     background-color: #f5f5f5;
@@ -212,12 +214,11 @@ const gStyle = css`
     padding: 0;
   }
 
-  // 폰트는 추후 반영 예정
-  /* @font-face {
+  @font-face {
     font-family: Pretendard;
     src: url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.6/dist/web/static/pretendard.css") format ("woff");
     font-display: swap;
-  } */
+  }
 `;
 
 export default gStyle;

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -214,12 +214,6 @@ const gStyle = css`
 
     padding: 0;
   }
-
-  @font-face {
-    font-family: Pretendard;
-    src: url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.6/dist/web/static/pretendard.css") format ("woff");
-    font-display: swap;
-  }
 `;
 
 export default gStyle;

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -180,6 +180,7 @@ const gStyle = css`
 
     background-color: #f5f5f5;
     max-width: 43rem;
+    height: 100dvh;
     -ms-overflow-style: none; /* 인터넷 익스플로러 */
     scrollbar-width: none; /* 파이어폭스 */
   }

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,85 @@
+import { Theme } from "@emotion/react";
+
+declare module "@emotion/react" {
+  export interface Theme {
+    colors: typeof colors;
+    fonts: typeof fonts;
+  }
+}
+
+const colors = {
+  main_mint: "#14C3BC",
+  sub_1: "#A1E7E4",
+  sub_2: "#E0FFFE",
+  sub_3: "#F3FDFC",
+  black_1: "#212121",
+  black_2: "#333333",
+  gray_1: "#666666",
+  gray_2: "#888888",
+  gray_3: "#999999",
+  light_1: "#D9D9D9",
+  light_2: "#F0F0F0",
+  light_3: "#FBFBFB",
+  light_4: "#FFFFFF",
+  blue_gray: "#F1F5F5",
+};
+
+const fonts = {
+  title1: {
+    fontFamily: "Pretendard",
+    fontWeight: 700,
+    fontSize: "2.4rem",
+  },
+  title2: {
+    fontFamily: "Pretendard",
+    fontWeight: 600,
+    fontSize: "2rem",
+  },
+  subtitle1: {
+    fontFamily: "Pretendard",
+    fontWeight: 700,
+    fontSize: "1.6rem",
+  },
+  subtitle2: {
+    fontFamily: "Pretendard",
+    fontWeight: 600,
+    fontSize: "1.6rem",
+  },
+  body1: {
+    fontFamily: "Pretendard",
+    fontWeight: 500,
+    fontSize: "1.6rem",
+  },
+  body2: {
+    fontFamily: "Pretendard",
+    fontWeight: 500,
+    fontSize: "1.4rem",
+  },
+  body3: {
+    fontFamily: "Pretendard",
+    fontWeight: 400,
+    fontSize: "1.4rem",
+  },
+  description1: {
+    fontFamily: "Pretendard",
+    fontWeight: 500,
+    fontSize: "1.2rem",
+  },
+  description2: {
+    fontFamily: "Pretendard",
+    fontWeight: 600,
+    fontSize: "1.2rem",
+  },
+  description3: {
+    fontFamily: "Pretendard",
+    fontWeight: 600,
+    fontSize: "0.8rem",
+  },
+};
+
+const theme: Theme = {
+  colors,
+  fonts,
+};
+
+export default theme;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -29,51 +29,61 @@ const fonts = {
     fontFamily: "Pretendard",
     fontWeight: 700,
     fontSize: "2.4rem",
+    lineHeight: 1.36,
   },
   title2: {
     fontFamily: "Pretendard",
     fontWeight: 600,
     fontSize: "2rem",
+    lineHeight: 1,
   },
   subtitle1: {
     fontFamily: "Pretendard",
     fontWeight: 700,
     fontSize: "1.6rem",
+    lineHeight: 1,
   },
   subtitle2: {
     fontFamily: "Pretendard",
     fontWeight: 600,
     fontSize: "1.6rem",
+    lineHeight: 1,
   },
   body1: {
     fontFamily: "Pretendard",
     fontWeight: 500,
     fontSize: "1.6rem",
+    lineHeight: 1.36,
   },
   body2: {
     fontFamily: "Pretendard",
     fontWeight: 500,
     fontSize: "1.4rem",
+    lineHeight: "normal",
   },
   body3: {
     fontFamily: "Pretendard",
     fontWeight: 400,
     fontSize: "1.4rem",
+    lineHeight: "normal",
   },
   description1: {
     fontFamily: "Pretendard",
     fontWeight: 500,
     fontSize: "1.2rem",
+    lineHeight: "normal",
   },
   description2: {
     fontFamily: "Pretendard",
     fontWeight: 600,
     fontSize: "1.2rem",
+    lineHeight: "1.36",
   },
   description3: {
     fontFamily: "Pretendard",
     fontWeight: 600,
     fontSize: "0.8rem",
+    lineHeight: "normal",
   },
 };
 


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #11 

## ✅ 작업 내용

프로젝트에서 사용될 font와 theme을 세팅했어요.

프로젝트 font는 현재 `Pretendard`로 통일되어 있어 `index.html`의 `head` 태그 내부에서 `Pretendard` 폰트를 불러오도록 했어요.

theme에는 `colors`와 `fonts` 토큰이 있고, style 컴포넌트 내부에서 다음과 같이 사용하면 돼요.

```ts
// color 적용
color: ${({ theme }) => theme.colors.light_3};
background-color: ${({ theme }) => theme.colors.main_mint};

// font 적용
${({ theme }) => theme.fonts.title2};
```

- 추가 작업
주희가 전에 뷰포트 높이 전체를 차지한 상태로 페이지 개발하고 싶다고 해서 root style에 `height: 100dvh`를 추가했어요.