### PR TITLE
feat: 공통 Button 컴포넌트를 구현합니다.

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,12 +1,14 @@
 import type { Preview } from "@storybook/react";
 import React from "react";
-import { ThemeProvider } from "@emotion/react";
+import { Global, ThemeProvider } from "@emotion/react";
 import theme from "../src/styles/theme";
+import gStyle from "../src/styles/GlobalStyles";
 
 const preview: Preview = {
   decorators: [
     (Story) => (
       <ThemeProvider theme={theme}>
+        <Global styles={gStyle} />
         <Story />
       </ThemeProvider>
     ),

--- a/src/components/Common/Button/Button.stories.tsx
+++ b/src/components/Common/Button/Button.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Button from "./Button";
+import styled from "@emotion/styled";
+
+const Container = styled.div`
+  width: 100vw;
+  max-width: 43rem;
+  padding: 0 2rem;
+`;
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+const meta = {
+  title: "Button",
+  component: Button,
+  decorators: [
+    (Story) => (
+      <Container>
+        <Story />
+      </Container>
+    ),
+  ],
+  parameters: {
+    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
+    layout: "centered",
+  },
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ["autodocs"],
+  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+  argTypes: {
+    // backgroundColor: { control: "color" },
+  },
+  // Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
+  args: {},
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
+export const Default: Story = {
+  args: {
+    children: "활성화 상태",
+    onClick: () => alert("활성화 버튼이 클릭되었습니다."),
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    children: "비활성화 상태",
+    disabled: true,
+    onClick: () => alert("비활성화 버튼이 클릭되었습니다."),
+  },
+};

--- a/src/components/Common/Button/Button.tsx
+++ b/src/components/Common/Button/Button.tsx
@@ -1,0 +1,23 @@
+import styled from "@emotion/styled";
+import { type ButtonHTMLAttributes, ReactNode } from "react";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: ReactNode;
+}
+
+function Button({ children, ...buttonElementProps }: ButtonProps) {
+  return <TinUButton {...buttonElementProps}>{children}</TinUButton>;
+}
+
+const TinUButton = styled.button<{ disabled?: boolean }>`
+  width: 100%;
+  height: 5.5rem;
+
+  ${({ theme }) => theme.fonts.title2};
+  color: ${({ theme, disabled }) => (disabled ? theme.colors.gray_3 : theme.colors.light_4)};
+
+  border-radius: 1.2rem;
+  background-color: ${({ theme, disabled }) => (disabled ? theme.colors.light_6 : theme.colors.main_mint)};
+`;
+
+export default Button;

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -178,7 +178,6 @@ const gStyle = css`
   html {
     margin: 0 auto;
 
-    background-color: #f5f5f5;
     max-width: 43rem;
     height: 100dvh;
     -ms-overflow-style: none; /* 인터넷 익스플로러 */

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -22,6 +22,7 @@ const colors = {
   light_2: "#F0F0F0",
   light_3: "#FBFBFB",
   light_4: "#FFFFFF",
+  light_6: "#F4F4F6",
   blue_gray: "#F1F5F5",
   red: "#F65E5E",
 };


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #15 

## ✅ 작업 내용

프로젝트 전반 공통으로 사용될 Button 컴포넌트를 구현했어요.

Default(활성화) / Disabled(비활성화) 2가지 case로 나뉘며, 기존 button 태그와 동일하게 `disabled` 라는 옵셔널 boolean prop으로 활성화 여부를 제어하면 돼요.

Button 컴포넌트는 Storybook에서 확인이 가능해요.

## 📸 스크린샷 / GIF / Link

- 활성화 상태 (disabled=false)
<img width="415" alt="image" src="https://github.com/user-attachments/assets/5b2b1498-9918-4ffb-bb0b-c202387b8056">


- 비활성화 상태 (disabled=true)
<img width="426" alt="image" src="https://github.com/user-attachments/assets/943ce444-b0e7-4e30-b3e9-bb31392eccf3">



https://github.com/user-attachments/assets/344e8c30-6229-4755-bdac-7bef20061708

