### PR TITLE
TINU-89 feat: Docker 컨테이너에 SSL 인증서를 마운트하도록 Dockerfile & deploy workflow를 수정합니다.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Docker Build and Deploy
 on:
   push:
     branches:
-      - main
+      - feat/#34_ssl
 
 jobs:
   build:
@@ -45,4 +45,4 @@ jobs:
             docker stop tinu-client || true
             docker rm tinu-client || true
             docker pull ${{ secrets.DOCKER_USERNAME }}/tinu-client
-            docker run -d -p 80:80 --name tinu-client ${{ secrets.DOCKER_USERNAME }}/tinu-client
+            docker run -d -p 80:80 --name tinu-client -v /etc/letsencrypt:/etc/letsencrypt:ro ${{ secrets.DOCKER_USERNAME }}/tinu-client

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Docker Build and Deploy
 on:
   push:
     branches:
-      - feat/#34_ssl
+      - main
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,4 +45,4 @@ jobs:
             docker stop tinu-client || true
             docker rm tinu-client || true
             docker pull ${{ secrets.DOCKER_USERNAME }}/tinu-client
-            docker run -d -p 80:80 --name tinu-client -v /etc/letsencrypt:/etc/letsencrypt:ro ${{ secrets.DOCKER_USERNAME }}/tinu-client
+            docker run -d -p 8080:80 --name tinu-client -v /etc/letsencrypt:/etc/letsencrypt:ro ${{ secrets.DOCKER_USERNAME }}/tinu-client

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ FROM nginx:alpine
 
 COPY --from=build /app/dist /usr/share/nginx/html
 
-EXPOSE 80
+EXPOSE 8080
 
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #34 

## ✅ 작업 내용
Docker 컨테이너에 SSL 인증서를 마운트하도록 Dockerfile & deploy workflow를 수정했어요.

먼저 가비아에서 구매한 도메인에 저희 Public IP를 연결해두었어요.
그 후 EC2에 진입해서 nginx를 설치하고 설정파일 생성 및 설정 활성화를 시켜주었어요.
그 후 인증서를 발급받고, Docker 컨테이너에 SSL 인증서를 마운트하도록 deploy workflow를 수정해주었어요.

그런데 CI/CD 과정에서 port 80에서 충돌이 발생했어요.
그 이유는 기본적으로 nginx가 port 80을 사용하는데, 기존에 Docker 컨테이너를 port 80에 바인딩하고 있었기 때문에 run command에서 포트 충돌이 발생했던 것이었어요.

이를 해결하기 위해 먼저 Dockerfile에서 컨테이너가 port 8080을 사용하도록 수정했어요.
또 deploy.yml 파일에서 Docker 컨테이너를 port 8080에 바인딩하도록 수정했어요.
마지막으로 EC2에 진입해서 nginx 설정 파일에서 프록시 대상 port를 8080으로 변경해주었어요.

현재 CI/CD workflow가 정상적으로 동작하는 상태이고, https://tinu.co.kr 로 접속이 가능해요!!
