### PR TITLE
bugfix: 약관동의 페이지 레이아웃 height 계산 오류를 수정합니다.

### DIFF
--- a/src/app/sign-up/layout.css.ts
+++ b/src/app/sign-up/layout.css.ts
@@ -1,0 +1,15 @@
+import { style } from "@vanilla-extract/css";
+
+export const layoutWrapper = style({
+  display: "flex",
+  flexDirection: "column",
+
+  width: "100%",
+  height: "100dvh",
+});
+
+export const mainContent = style({
+  flex: 1,
+
+  padding: "0 2rem",
+});

--- a/src/app/sign-up/layout.tsx
+++ b/src/app/sign-up/layout.tsx
@@ -2,11 +2,13 @@ import { Header } from "@/components/Common/Header/Header";
 import { PropsWithChildren } from "react";
 import { BackButton } from "@/components/Common/BackButton/BackButton";
 
+import * as styles from "./layout.css";
+
 export default function Layout({ children }: PropsWithChildren) {
   return (
-    <>
+    <div className={styles.layoutWrapper}>
       <Header left={<BackButton />} />
-      {children}
-    </>
+      <main className={styles.mainContent}>{children}</main>
+    </div>
   );
 }

--- a/src/app/sign-up/terms/page.tsx
+++ b/src/app/sign-up/terms/page.tsx
@@ -5,15 +5,13 @@ import { MemoizedStepIcon } from "@/components/SignUp/StepIcon/StepIcon";
 
 export default function page() {
   return (
-    <div className={styles.step1Container}>
-      <div className={styles.step1Wrapper}>
-        <MemoizedStepIcon step={1} />
-        <h1 className={styles.titleWrapper}>
-          간편 회원가입을 위해 <br />
-          약관 동의가 필요해요
-        </h1>
-        <TermsForm />
-      </div>
+    <div className={styles.termsPageWrapper}>
+      <MemoizedStepIcon step={1} />
+      <h1 className={styles.titleWrapper}>
+        간편 회원가입을 위해 <br />
+        약관 동의가 필요해요
+      </h1>
+      <TermsForm />
     </div>
   );
 }

--- a/src/app/sign-up/terms/terms.css.ts
+++ b/src/app/sign-up/terms/terms.css.ts
@@ -1,13 +1,7 @@
 import { vars } from "@/styles/theme.css";
 import { style } from "@vanilla-extract/css";
 
-export const step1Container = style({
-  width: "100%",
-  height: "100dvh",
-  padding: "0 2rem",
-});
-
-export const step1Wrapper = style({
+export const termsPageWrapper = style({
   display: "flex",
   flexDirection: "column",
 

--- a/src/components/Common/Header/Header.tsx
+++ b/src/components/Common/Header/Header.tsx
@@ -1,17 +1,18 @@
-import * as styles from './header.css';
+import * as styles from "./header.css";
 
 interface HeaderProps {
-    left?: React.ReactNode;
-    center?: React.ReactNode;
-    right?: React.ReactNode;
-  }
+  left?: React.ReactNode;
+  center?: React.ReactNode;
+  right?: React.ReactNode;
+  isSticky?: boolean;
+}
 
-  export function Header({ left, center, right }: HeaderProps) {
-    return (
-      <header className={styles.headerWrapper} aria-label="페이지 헤더">
-        <div className={styles.leftElement}>{left}</div>
-        <h2 className={styles.centerElement}>{center}</h2>
-        <div className={styles.rightElement}>{right}</div>
-      </header>
-    );
-  }
+export function Header({ left, center, right, isSticky = false }: HeaderProps) {
+  return (
+    <header className={styles.headerWrapper({ isSticky })} aria-label="페이지 헤더">
+      <div className={styles.leftElement}>{left}</div>
+      <h2 className={styles.centerElement}>{center}</h2>
+      <div className={styles.rightElement}>{right}</div>
+    </header>
+  );
+}

--- a/src/components/Common/Header/header.css.ts
+++ b/src/components/Common/Header/header.css.ts
@@ -1,35 +1,47 @@
-import { Z_INDEX } from '@/constants/zIndex';
-import { style } from '@vanilla-extract/css';
+import { Z_INDEX } from "@/constants/zIndex";
+import { style } from "@vanilla-extract/css";
+import { recipe } from "@vanilla-extract/recipes";
 
-export const headerWrapper = style({
-  position: 'sticky',
-  zIndex: Z_INDEX.HEADER,
-  top: 0,
-  display: 'flex',
-  width: '100%',
-  height: '6rem',
-  backgroundColor: 'white'
-  });
+export const headerWrapper = recipe({
+  base: {
+    zIndex: Z_INDEX.HEADER,
+    top: 0,
+    display: "flex",
+    width: "100%",
+    height: "6rem",
+    backgroundColor: "white",
+  },
+  variants: {
+    isSticky: {
+      true: {
+        position: "sticky",
+      },
+      false: {
+        position: "relative",
+      },
+    },
+  },
+});
 
 export const leftElement = style({
-  display: 'flex',
-  alignItems: 'center',
-  position: 'absolute',
-  left: '2rem',
-  height: '100%'
+  display: "flex",
+  alignItems: "center",
+  position: "absolute",
+  left: "2rem",
+  height: "100%",
 });
 
 export const centerElement = style({
-  display: 'flex',
-  alignItems: 'center',
-  margin: '0 auto',
-  height: '100%'
+  display: "flex",
+  alignItems: "center",
+  margin: "0 auto",
+  height: "100%",
 });
 
 export const rightElement = style({
-  display: 'flex',
-  alignItems: 'center',
-  position: 'absolute',
-  right: '2rem',
-  height: '100%'
+  display: "flex",
+  alignItems: "center",
+  position: "absolute",
+  right: "2rem",
+  height: "100%",
 });


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #62 

## ✅ 작업 내용

약관동의 페이지 레이아웃 height 계산 오류를 수정했어요. 이제 모든 브라우저 및 모든 디바이스에서 fit하게 height가 계산돼요.

추가적으로, Header에 `isSticky`라는 optional 인터페이스를 추가했어요.
Header가 sticky처럼 동작해야 하는 곳에만 `isSticky`를 true로 넘겨주면 됩니다!!
