### PR TITLE
fix: StepIcon 컴포넌트 레이아웃을 수정합니다.

### DIFF
--- a/src/app/sign-up/terms/terms.css.ts
+++ b/src/app/sign-up/terms/terms.css.ts
@@ -12,6 +12,6 @@ export const termsPageWrapper = style({
 export const titleWrapper = style({
   ...vars.fontStyles.title2_sb_22,
 
-  marginTop: "3.5rem",
+  marginTop: "5.2rem",
   paddingLeft: "1rem",
 });

--- a/src/components/SignUp/StepIcon/StepIcon.tsx
+++ b/src/components/SignUp/StepIcon/StepIcon.tsx
@@ -29,19 +29,19 @@ export function StepIcon({ step }: StepIconProps) {
 
         if (currentStep === step) {
           const StepComponent = STEP_CONFIG[step].Icon;
-          return (
-            <div className={styles.stepIconWrapper} key={index}>
-              <StepComponent />
-              <span className={styles.stepText}>{STEP_CONFIG[step].text}</span>
-            </div>
-          );
+          return <StepComponent key={currentStep} />;
         }
 
-        return currentStep < step ? <IcCheckTransparent key={index} /> : <IcGreyCircle key={index} />;
+        return currentStep < step ? <IcCheckTransparent key={currentStep} /> : <IcGreyCircle key={currentStep} />;
       });
   };
 
-  return <div className={styles.stepIconContainer}>{renderIcons()}</div>;
+  return (
+    <div className={styles.stepIconWrapper}>
+      <div className={styles.stepIconListContainer}>{renderIcons()}</div>
+      <span className={styles.stepText({ step })}>{STEP_CONFIG[step].text}</span>
+    </div>
+  );
 }
 
 export const MemoizedStepIcon = memo(StepIcon);

--- a/src/components/SignUp/StepIcon/stepIcon.css.ts
+++ b/src/components/SignUp/StepIcon/stepIcon.css.ts
@@ -1,23 +1,32 @@
 import { vars } from "@/styles/theme.css";
 import { style } from "@vanilla-extract/css";
+import { recipe } from "@vanilla-extract/recipes";
 
-export const stepIconContainer = style({
-  display: "flex",
-  gap: "0.5rem",
-
+export const stepIconWrapper = style({
+  position: "relative",
   marginTop: "0.8rem",
 });
 
-export const stepIconWrapper = style({
+export const stepIconListContainer = style({
   display: "flex",
-  flexDirection: "column",
-  alignItems: "center",
+  gap: "0.6rem",
+  paddingLeft: "1.05rem",
 });
 
-export const stepText = style({
-  ...vars.fontStyles.caption1_m_11,
+export const stepText = recipe({
+  base: {
+    ...vars.fontStyles.caption1_m_11,
 
-  marginTop: "0.3rem",
+    position: "absolute",
+    top: "2.2rem",
+    width: "fit-content",
 
-  color: vars.color.grey_6,
+    color: vars.color.grey_6,
+  },
+  variants: {
+    step: Object.fromEntries([1, 2, 3, 4].map((step) => [step, { left: `${(step - 1) * 2.4}rem` }])) as Record<
+      1 | 2 | 3 | 4,
+      { left: string }
+    >,
+  },
 });

--- a/src/components/SignUp/StepIcon/stepIcon.css.ts
+++ b/src/components/SignUp/StepIcon/stepIcon.css.ts
@@ -24,9 +24,11 @@ export const stepText = recipe({
     color: vars.color.grey_6,
   },
   variants: {
-    step: Object.fromEntries([1, 2, 3, 4].map((step) => [step, { left: `${(step - 1) * 2.4}rem` }])) as Record<
-      1 | 2 | 3 | 4,
-      { left: string }
-    >,
+    step: {
+        1: { left: 0 },
+        2: { left: "2.4rem" },
+        3: { left: "4.8rem" },
+        4: { left: "7.2rem" } 
+    }
   },
 });


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #66 

## ✅ 작업 내용
StepIcon 컴포넌트 레이아웃을 수정했어요.

디자인 상 아이콘과 텍스트의 영역이 겹쳐있는 구조라 텍스트를 absoute positioning으로 문서 흐름에서 분리시켰어요.

단계가 진행될수록 텍스트가 우측으로 이동해요. 처음에는 1단계의 텍스트 위치 기준값을 0으로 잡고, 단계별로 텍스트가 이동하는 값만큼 각각 left 속성값을 부여했어요.

```ts
variants: {
    step: {
        1: { left: 0 },
        2: { left: "2.4rem" },
        3: { left: "4.8rem" },
        4: { left: "7.2rem" } 
    }
},
```

작성을 하고 보니, step이 1 증가할때마다 규칙적으로 "2.4rem"씩 이동하는 규칙을 확인할 수 있었어요.
그렇다면 이 step별 left 수치값을 동적으로 자동생성하게 할 수 있지 않을까? 라는 생각을 하게 되었어요.

그래서 코드를 다음과 같이 리팩토링했어요.

```ts
variants: {
    step: Object.fromEntries([1, 2, 3, 4].map((step) => [step, { left: `${(step - 1) * 2.4}rem` }])) as Record<
      1 | 2 | 3 | 4,
      { left: string }
    >,
},
```

실제로 위 코드와 똑같이 동작하면서, 만약 5단계가 추가된다 해도 배열에 5만 추가하고 타입만 맞춰주면 수치가 "9.6rem"으로 잘 계산돼요.

하지만 이 방식에는 허점이 있어요.
"2.4rem"이라는 수치는 글자 길이에 비례한 수치에요. 지금은 글자 길이가 모두 4글자라서 균일한 수치만큼 이동했는데, 만약 다음 스텝의 글자가 3글자라면 4글자인 경우보다 더 이동해야 할 것이고, 5글자라면 덜 이동해야 할 거예요. 나중에 UX라이팅이 변경되거나 새로운 스텝이 추가될 때의 텍스트 길이가 4글자라는 것을 보장할 수 없어요. 그래서 수치를 자동 계산하는 로직을 짜두는 것이 유지보수성을 저하시킬 수도 있다고 생각해서 다시 각 step마다 이동 수치값을 직접 넣어주는 기존 구현 방식으로 수정했어요.

## 📸 스크린샷 / GIF / Link
<img width="133" alt="스크린샷 2025-02-21 오전 11 09 33" src="https://github.com/user-attachments/assets/49d49551-4fb3-4541-bea4-a58f60b107cd" />
<img width="117" alt="스크린샷 2025-02-21 오전 11 09 50" src="https://github.com/user-attachments/assets/849312e9-5b2f-4241-a8ac-fd6e2ec54b88" />
<img width="122" alt="스크린샷 2025-02-21 오전 11 10 10" src="https://github.com/user-attachments/assets/bea9ce7d-6e91-4da7-b69c-55e0d56f7895" />
<img width="123" alt="스크린샷 2025-02-21 오전 11 10 24" src="https://github.com/user-attachments/assets/a9efe6d5-9eea-4cb5-8b04-09e250df0029" />


