### PR TITLE
feat: 회원가입-회원정보입력 페이지 퍼블리싱

### DIFF
--- a/src/app/sign-up/info/info.css.ts
+++ b/src/app/sign-up/info/info.css.ts
@@ -1,0 +1,25 @@
+import { vars } from "@/styles/theme.css";
+import { style } from "@vanilla-extract/css";
+
+export const infoPageWrapper = style({
+  display: "flex",
+  flexDirection: "column",
+
+  width: "100%",
+  height: "100%",
+});
+
+export const titleWrapper = style({
+  ...vars.fontStyles.title2_sb_22,
+
+  marginTop: "5.2rem",
+  paddingLeft: "1rem",
+});
+
+export const descriptionWrapper = style({
+  ...vars.fontStyles.body2_m_14,
+  color: vars.color.grey_6,
+
+  marginTop: "0.5rem",
+  paddingLeft: "1rem",
+});

--- a/src/app/sign-up/info/page.tsx
+++ b/src/app/sign-up/info/page.tsx
@@ -1,3 +1,17 @@
+import UserProfileForm from "@/components/SignUp/Info/UserProfileForm/UserProfileForm";
+import * as styles from "./info.css";
+
+import { MemoizedStepIcon } from "@/components/SignUp/StepIcon/StepIcon";
+
 export default function page() {
-  return <></>;
+  return (
+    <>
+      <div className={styles.infoPageWrapper}>
+        <MemoizedStepIcon step={3} />
+        <h1 className={styles.titleWrapper}>나만의 프로필을 설정하세요</h1>
+        <h2 className={styles.descriptionWrapper}>마이페이지에서 언제든 수정 가능해요</h2>
+        <UserProfileForm />
+      </div>
+    </>
+  );
 }

--- a/src/assets/icons/ic_profile.svg
+++ b/src/assets/icons/ic_profile.svg
@@ -1,0 +1,24 @@
+<svg width="113" height="112" viewBox="0 0 113 112" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="1.5" y="1" width="110" height="110" rx="55" fill="#F2F2F2"/>
+<rect x="1.5" y="1" width="110" height="110" rx="55" stroke="#DEDEDE" stroke-width="1.27907"/>
+<g filter="url(#filter0_d_4387_4071)">
+<circle cx="94.1279" cy="91.6279" r="16.6279" fill="#14C3BC"/>
+<circle cx="94.1279" cy="91.6279" r="15.9884" stroke="white" stroke-width="1.27907"/>
+</g>
+<path d="M87.5 91H101.5" stroke="white" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M94.5 84L94.5 98" stroke="white" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="10.8333" cy="10.8333" r="10.8333" transform="matrix(-1 0 0 1 66.292 33.125)" fill="#C8C8C8"/>
+<path d="M36.5 70.8644C36.5 68.5343 37.9648 66.4557 40.1592 65.672C50.0526 62.1386 60.8641 62.1386 70.7575 65.672C72.9519 66.4557 74.4167 68.5343 74.4167 70.8644V74.4272C74.4167 77.6432 71.5683 80.1136 68.3846 79.6588L65.7998 79.2895C58.9403 78.3096 51.9764 78.3096 45.1169 79.2895L42.532 79.6588C39.3484 80.1136 36.5 77.6432 36.5 74.4272V70.8644Z" fill="#C8C8C8"/>
+<defs>
+<filter id="filter0_d_4387_4071" x="76.2209" y="73.7209" width="35.814" height="35.814" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="0.639535"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4387_4071"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_4387_4071" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/src/components/SignUp/Info/ImageInputForm/ImageInputForm.css.ts
+++ b/src/components/SignUp/Info/ImageInputForm/ImageInputForm.css.ts
@@ -6,5 +6,3 @@ export const ImageInputFormWrapper = style({
 
   width: "100%",
 });
-
-export const ImageInputButton = style({});

--- a/src/components/SignUp/Info/ImageInputForm/ImageInputForm.css.ts
+++ b/src/components/SignUp/Info/ImageInputForm/ImageInputForm.css.ts
@@ -1,0 +1,10 @@
+import { style } from "@vanilla-extract/css";
+
+export const ImageInputFormWrapper = style({
+  display: "flex",
+  flexDirection: "column",
+
+  width: "100%",
+});
+
+export const ImageInputButton = style({});

--- a/src/components/SignUp/Info/ImageInputForm/ImageInputForm.tsx
+++ b/src/components/SignUp/Info/ImageInputForm/ImageInputForm.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import * as styles from "./ImageInputForm.css";
+import IcProfile from "@/assets/icons/ic_profile.svg";
+
+function ImageInputForm() {
+  return (
+    <div className={styles.ImageInputFormWrapper}>
+      <button type="button" className={styles.ImageInputButton}>
+        <IcProfile />
+      </button>
+    </div>
+  );
+}
+
+export default ImageInputForm;

--- a/src/components/SignUp/Info/ImageInputForm/ImageInputForm.tsx
+++ b/src/components/SignUp/Info/ImageInputForm/ImageInputForm.tsx
@@ -6,7 +6,7 @@ import IcProfile from "@/assets/icons/ic_profile.svg";
 function ImageInputForm() {
   return (
     <div className={styles.ImageInputFormWrapper}>
-      <button type="button" className={styles.ImageInputButton}>
+      <button type="button">
         <IcProfile />
       </button>
     </div>

--- a/src/components/SignUp/Info/UserProfileForm/UserProfileForm.css.ts
+++ b/src/components/SignUp/Info/UserProfileForm/UserProfileForm.css.ts
@@ -1,0 +1,15 @@
+import { style } from "@vanilla-extract/css";
+
+export const userProfileFormWrapper = style({
+  flex: 1,
+
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "space-between",
+
+  marginTop: "5rem",
+});
+
+export const nicknameFieldWrapper = style({
+  marginTop: "3.5rem",
+});

--- a/src/components/SignUp/Info/UserProfileForm/UserProfileForm.tsx
+++ b/src/components/SignUp/Info/UserProfileForm/UserProfileForm.tsx
@@ -6,6 +6,7 @@ import * as styles from "./UserProfileForm.css";
 import ImageInputForm from "../ImageInputForm/ImageInputForm";
 import TextField from "@/components/Common/TextField/TextField";
 import { SubmitButton } from "../../Email/SubmitButton/SubmitButton";
+import { NICKNAME_MESSAGES } from "@/constants/message";
 
 function UserProfileForm() {
   const [nickname, setNickname] = useState("");
@@ -23,12 +24,12 @@ function UserProfileForm() {
   const isError = nickname !== "" && (!isValidNickname || isDuplicateNickname);
   const helperText =
     nickname === ""
-      ? ""
+      ? NICKNAME_MESSAGES.EMPTY
       : !isValidNickname
-        ? "닉네임은 2~15자여야 해요!"
+        ? NICKNAME_MESSAGES.INVALID_LENGTH
         : isDuplicateNickname
-          ? "이미 사용중인 닉네임이에요 :("
-          : "사용 가능한 닉네임이에요";
+          ? NICKNAME_MESSAGES.DUPLICATE
+          : NICKNAME_MESSAGES.AVAILABLE;
 
   return (
     <div className={styles.userProfileFormWrapper}>

--- a/src/components/SignUp/Info/UserProfileForm/UserProfileForm.tsx
+++ b/src/components/SignUp/Info/UserProfileForm/UserProfileForm.tsx
@@ -44,7 +44,7 @@ function UserProfileForm() {
           />
         </div>
       </div>
-      <SubmitButton disabled={true} />
+      <SubmitButton disabled={!isAvailableNickname} />
     </div>
   );
 }

--- a/src/components/SignUp/Info/UserProfileForm/UserProfileForm.tsx
+++ b/src/components/SignUp/Info/UserProfileForm/UserProfileForm.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import React, { useState } from "react";
+
+import * as styles from "./UserProfileForm.css";
+import ImageInputForm from "../ImageInputForm/ImageInputForm";
+import TextField from "@/components/Common/TextField/TextField";
+import { SubmitButton } from "../../Email/SubmitButton/SubmitButton";
+
+function UserProfileForm() {
+  const [nickname, setNickname] = useState("");
+
+  const isValidNickname = nickname.length >= 2 && nickname.length <= 15;
+  const isDuplicateNickname = false; //
+  const isAvailableNickname = isValidNickname && !isDuplicateNickname && nickname !== "";
+
+  const handleNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputValue = e.target.value;
+    if (/[^가-힣a-zA-Z0-9]/.test(inputValue)) return;
+    setNickname(inputValue);
+  };
+
+  const isError = nickname !== "" && (!isValidNickname || isDuplicateNickname);
+  const helperText =
+    nickname === ""
+      ? ""
+      : !isValidNickname
+        ? "닉네임은 2~15자여야 해요!"
+        : isDuplicateNickname
+          ? "이미 사용중인 닉네임이에요 :("
+          : "사용 가능한 닉네임이에요";
+
+  return (
+    <div className={styles.userProfileFormWrapper}>
+      <div>
+        <ImageInputForm />
+        <div className={styles.nicknameFieldWrapper}>
+          <TextField
+            placeholder="닉네임을 입력하세요"
+            isError={isError}
+            onChange={handleNicknameChange}
+            value={nickname}
+            helperText={helperText}
+          />
+        </div>
+      </div>
+      <SubmitButton disabled={true} />
+    </div>
+  );
+}
+
+export default UserProfileForm;

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -1,0 +1,11 @@
+export const EMAIL_MESSAGES = {
+  EMPTY: "",
+  INVALID: "학교 계정이 아닌 것 같아요 :(",
+};
+
+export const NICKNAME_MESSAGES = {
+  EMPTY: "",
+  INVALID_LENGTH: "닉네임은 2~15자여야 해요!",
+  DUPLICATE: "이미 사용중인 닉네임이에요 :(",
+  AVAILABLE: "사용 가능한 닉네임이에요",
+};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #75 

## ✅ 작업 내용
회원가입 - 정보 입력 페이지 퍼블리싱을 완료했어요!!

이미지 업로드 영역, 닉네임 입력 필드, 다음 버튼을 `UserProfileForm` 클라이언트 컴포넌트로 분리했어요.
이미지 업로드 컴포넌트(`ImageInputForm`)는 퍼블리싱만 진행했으며, 기능 구현은 추후 PR로 추가할 예정이에요.

현재 `UserProfileForm` 내 isDuplicateNickname 변수는 임시값으로 설정되어 있으며, 추후 API를 연결해 닉네임 중복 여부를 판별할 계획입니다.

닉네임 입력 관련 기능은 다음과 같이 동작해요
- 닉네임은 2~15자 사이만 허용
- 한글, 영문, 숫자만 입력 가능하도록 정규식 적용 (특수문자 입력 불가)

- 닉네임 상태에 따른 UI 동작
  - 입력 전: helperText 미표시
  - 2 ~ 15자가 아닐 경우: "닉네임은 2~15자여야 해요!"
  - 중복된 닉네임일 경우: "이미 사용 중인 닉네임이에요 :("
  - 사용 가능한 닉네임일 경우: "사용 가능한 닉네임이에요"
  - 사용 가능한 닉네임일 때만 SubmitButton 활성화
 
## 📸 스크린샷 / GIF / Link
https://github.com/user-attachments/assets/770536f1-25cd-4c5f-b3b0-5cbd0ae706f2
