### PR TITLE
feat: IconButton 구현

### DIFF
--- a/src/app/(with-navbar)/(with-logo-header)/chat-list/page.tsx
+++ b/src/app/(with-navbar)/(with-logo-header)/chat-list/page.tsx
@@ -3,11 +3,10 @@
 import { FilterButton } from "@/components/ChatList/FilterButton/FilterButton";
 import * as styles from "./chatList.css";
 
+import { ImgChatEmpty } from "@/assets/imgs";
 import { ChatListItem } from "@/components/ChatList/ChatListItem/ChatListItem";
 import { FilterOption } from "@/types/chatListTypes";
 import { useState } from "react";
-
-import ImgChatEmpty from "@/assets/imgs/img_chat_empty.svg";
 
 const FILTER_OPTIONS: FilterOption[] = ["전체", "판매", "구매"];
 

--- a/src/app/(with-navbar)/(with-logo-header)/layout.tsx
+++ b/src/app/(with-navbar)/(with-logo-header)/layout.tsx
@@ -1,5 +1,5 @@
-import IcHamburger from "@/assets/icons/ic_hamburger.svg";
-import ImgLogoSmall from "@/assets/imgs/img_logo_small.svg";
+import { IcHamburger } from "@/assets/icons";
+import { ImgLogoSmall } from "@/assets/imgs";
 import { Header } from "@/components/Common/Header/Header";
 import { IconButton } from "@/components/Common/IconButton";
 import Link from "next/link";

--- a/src/app/(with-navbar)/(with-logo-header)/layout.tsx
+++ b/src/app/(with-navbar)/(with-logo-header)/layout.tsx
@@ -1,21 +1,19 @@
-import { Header } from "@/components/Common/Header/Header";
-import ImgLogoSmall from "@/assets/imgs/img_logo_small.svg";
 import IcHamburger from "@/assets/icons/ic_hamburger.svg";
+import ImgLogoSmall from "@/assets/imgs/img_logo_small.svg";
+import { Header } from "@/components/Common/Header/Header";
+import { IconButton } from "@/components/Common/IconButton";
+import Link from "next/link";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <>
       <Header
         left={
-          <button type="button">
+          <Link href="/">
             <ImgLogoSmall />
-          </button>
+          </Link>
         }
-        right={
-          <button type="button">
-            <IcHamburger />
-          </button>
-        }
+        right={<IconButton icon={<IcHamburger />} label="메뉴 열기" />}
         isSticky
       />
       {children}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,6 @@
+import { ImgLogoBig } from "@/assets/imgs";
 import { LoginButtonSection } from "@/components/Login/LoginButtonSection";
 import * as styles from "./login.css";
-import ImgLogoBig from "@/assets/imgs/img_logo_big.svg";
 
 export default function page() {
   return (

--- a/src/app/sign-up/done/page.tsx
+++ b/src/app/sign-up/done/page.tsx
@@ -1,4 +1,4 @@
-import IcSignUpDone from "@/assets/icons/ic_signup_done.svg";
+import { IcSignUpDone } from "@/assets/icons";
 import Button from "@/components/Common/Button/Button";
 import Confetti from "@/components/SignUp/Done/Confetti";
 import * as styles from "./done.css";

--- a/src/app/sign-up/done/page.tsx
+++ b/src/app/sign-up/done/page.tsx
@@ -1,7 +1,7 @@
-import * as styles from "./done.css";
-import ImgSignUpDone from "@/assets/icons/ic_signup_done.svg";
-import Confetti from "@/components/SignUp/Done/Confetti";
+import IcSignUpDone from "@/assets/icons/ic_signup_done.svg";
 import Button from "@/components/Common/Button/Button";
+import Confetti from "@/components/SignUp/Done/Confetti";
+import * as styles from "./done.css";
 
 export default function Page() {
   return (
@@ -12,7 +12,7 @@ export default function Page() {
           <div className={styles.confettiBackground}>
             <Confetti />
           </div>
-          <ImgSignUpDone className={styles.image} />
+          <IcSignUpDone className={styles.image} />
         </div>
       </div>
 

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -1,73 +1,7 @@
 import IcAirplaneGrey from "./ic_airplane_grey.svg";
 import IcAirplaneMint from "./ic_airplane_mint.svg";
-import IcArrowRight from "./ic_arrow_right.svg";
 import IcCamera from "./ic_camera.svg";
-import IcChatGrey from "./ic_chat_grey.svg";
-import IcChatMint from "./ic_chat_mint.svg";
-import IcCheckComplete from "./ic_check_complete.svg";
-import IcCheckGrey from "./ic_check_grey.svg";
-import IcCheckMint from "./ic_check_mint.svg";
-import IcCheckTransparent from "./ic_check_transparent.svg";
-import IcCheckWhiteGrey from "./ic_check_whitegrey.svg";
-import IcChevronDown from "./ic_chevron_down.svg";
 import IcChevronLeft from "./ic_chevron_left.svg";
-import IcChevronRight from "./ic_chevron_right.svg";
-import IcChevronUp from "./ic_chevron_up.svg";
-import IcClose from "./ic_close.svg";
-import IcGreyCircle from "./ic_grey_circle.svg";
-import IcHamburger from "./ic_hamburger.svg";
-import IcHomeGrey from "./ic_home_grey.svg";
-import IcHomeMint from "./ic_home_mint.svg";
-import IcLogoGoogle from "./ic_logo_google.svg";
-import IcLogoKakao from "./ic_logo_kakao.svg";
-import IcLogoNaver from "./ic_logo_naver.svg";
-import IcMoreVertical from "./ic_more_vertical.svg";
 import IcPlus from "./ic_plus.svg";
-import IcProfile from "./ic_profile.svg";
-import IcSignUpDone from "./ic_signup_done.svg";
-import IcStep1 from "./ic_step1.svg";
-import IcStep2 from "./ic_step2.svg";
-import IcStep3 from "./ic_step3.svg";
-import IcStep4 from "./ic_step4.svg";
-import IcSwap from "./ic_swap.svg";
-import IcTextLogo from "./ic_text_logo.svg";
-import IcTextLogoSmall from "./ic_text_logo_small.svg";
-import IcUserGrey from "./ic_user_grey.svg";
 
-export {
-  IcAirplaneGrey,
-  IcAirplaneMint,
-  IcArrowRight,
-  IcCamera,
-  IcChatGrey,
-  IcChatMint,
-  IcCheckComplete,
-  IcCheckGrey,
-  IcCheckMint,
-  IcCheckTransparent,
-  IcCheckWhiteGrey,
-  IcChevronDown,
-  IcChevronLeft,
-  IcChevronRight,
-  IcChevronUp,
-  IcClose,
-  IcGreyCircle,
-  IcHamburger,
-  IcHomeGrey,
-  IcHomeMint,
-  IcLogoGoogle,
-  IcLogoKakao,
-  IcLogoNaver,
-  IcMoreVertical,
-  IcPlus,
-  IcProfile,
-  IcSignUpDone,
-  IcStep1,
-  IcStep2,
-  IcStep3,
-  IcStep4,
-  IcSwap,
-  IcTextLogo,
-  IcTextLogoSmall,
-  IcUserGrey,
-};
+export { IcAirplaneGrey, IcAirplaneMint, IcCamera, IcChevronLeft, IcPlus };

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -1,7 +1,73 @@
 import IcAirplaneGrey from "./ic_airplane_grey.svg";
 import IcAirplaneMint from "./ic_airplane_mint.svg";
+import IcArrowRight from "./ic_arrow_right.svg";
 import IcCamera from "./ic_camera.svg";
+import IcChatGrey from "./ic_chat_grey.svg";
+import IcChatMint from "./ic_chat_mint.svg";
+import IcCheckComplete from "./ic_check_complete.svg";
+import IcCheckGrey from "./ic_check_grey.svg";
+import IcCheckMint from "./ic_check_mint.svg";
+import IcCheckTransparent from "./ic_check_transparent.svg";
+import IcCheckWhiteGrey from "./ic_check_whitegrey.svg";
+import IcChevronDown from "./ic_chevron_down.svg";
 import IcChevronLeft from "./ic_chevron_left.svg";
+import IcChevronRight from "./ic_chevron_right.svg";
+import IcChevronUp from "./ic_chevron_up.svg";
+import IcClose from "./ic_close.svg";
+import IcGreyCircle from "./ic_grey_circle.svg";
+import IcHamburger from "./ic_hamburger.svg";
+import IcHomeGrey from "./ic_home_grey.svg";
+import IcHomeMint from "./ic_home_mint.svg";
+import IcLogoGoogle from "./ic_logo_google.svg";
+import IcLogoKakao from "./ic_logo_kakao.svg";
+import IcLogoNaver from "./ic_logo_naver.svg";
+import IcMoreVertical from "./ic_more_vertical.svg";
 import IcPlus from "./ic_plus.svg";
+import IcProfile from "./ic_profile.svg";
+import IcSignUpDone from "./ic_signup_done.svg";
+import IcStep1 from "./ic_step1.svg";
+import IcStep2 from "./ic_step2.svg";
+import IcStep3 from "./ic_step3.svg";
+import IcStep4 from "./ic_step4.svg";
+import IcSwap from "./ic_swap.svg";
+import IcTextLogo from "./ic_text_logo.svg";
+import IcTextLogoSmall from "./ic_text_logo_small.svg";
+import IcUserGrey from "./ic_user_grey.svg";
 
-export { IcAirplaneGrey, IcAirplaneMint, IcCamera, IcChevronLeft, IcPlus };
+export {
+  IcAirplaneGrey,
+  IcAirplaneMint,
+  IcArrowRight,
+  IcCamera,
+  IcChatGrey,
+  IcChatMint,
+  IcCheckComplete,
+  IcCheckGrey,
+  IcCheckMint,
+  IcCheckTransparent,
+  IcCheckWhiteGrey,
+  IcChevronDown,
+  IcChevronLeft,
+  IcChevronRight,
+  IcChevronUp,
+  IcClose,
+  IcGreyCircle,
+  IcHamburger,
+  IcHomeGrey,
+  IcHomeMint,
+  IcLogoGoogle,
+  IcLogoKakao,
+  IcLogoNaver,
+  IcMoreVertical,
+  IcPlus,
+  IcProfile,
+  IcSignUpDone,
+  IcStep1,
+  IcStep2,
+  IcStep3,
+  IcStep4,
+  IcSwap,
+  IcTextLogo,
+  IcTextLogoSmall,
+  IcUserGrey,
+};

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -1,0 +1,73 @@
+import IcAirplaneGrey from "./ic_airplane_grey.svg";
+import IcAirplaneMint from "./ic_airplane_mint.svg";
+import IcArrowRight from "./ic_arrow_right.svg";
+import IcCamera from "./ic_camera.svg";
+import IcChatGrey from "./ic_chat_grey.svg";
+import IcChatMint from "./ic_chat_mint.svg";
+import IcCheckComplete from "./ic_check_complete.svg";
+import IcCheckGrey from "./ic_check_grey.svg";
+import IcCheckMint from "./ic_check_mint.svg";
+import IcCheckTransparent from "./ic_check_transparent.svg";
+import IcCheckWhiteGrey from "./ic_check_whitegrey.svg";
+import IcChevronDown from "./ic_chevron_down.svg";
+import IcChevronLeft from "./ic_chevron_left.svg";
+import IcChevronRight from "./ic_chevron_right.svg";
+import IcChevronUp from "./ic_chevron_up.svg";
+import IcClose from "./ic_close.svg";
+import IcGreyCircle from "./ic_grey_circle.svg";
+import IcHamburger from "./ic_hamburger.svg";
+import IcHomeGrey from "./ic_home_grey.svg";
+import IcHomeMint from "./ic_home_mint.svg";
+import IcLogoGoogle from "./ic_logo_google.svg";
+import IcLogoKakao from "./ic_logo_kakao.svg";
+import IcLogoNaver from "./ic_logo_naver.svg";
+import IcMoreVertical from "./ic_more_vertical.svg";
+import IcPlus from "./ic_plus.svg";
+import IcProfile from "./ic_profile.svg";
+import IcSignUpDone from "./ic_signup_done.svg";
+import IcStep1 from "./ic_step1.svg";
+import IcStep2 from "./ic_step2.svg";
+import IcStep3 from "./ic_step3.svg";
+import IcStep4 from "./ic_step4.svg";
+import IcSwap from "./ic_swap.svg";
+import IcTextLogo from "./ic_text_logo.svg";
+import IcTextLogoSmall from "./ic_text_logo_small.svg";
+import IcUserGrey from "./ic_user_grey.svg";
+
+export {
+  IcAirplaneGrey,
+  IcAirplaneMint,
+  IcArrowRight,
+  IcCamera,
+  IcChatGrey,
+  IcChatMint,
+  IcCheckComplete,
+  IcCheckGrey,
+  IcCheckMint,
+  IcCheckTransparent,
+  IcCheckWhiteGrey,
+  IcChevronDown,
+  IcChevronLeft,
+  IcChevronRight,
+  IcChevronUp,
+  IcClose,
+  IcGreyCircle,
+  IcHamburger,
+  IcHomeGrey,
+  IcHomeMint,
+  IcLogoGoogle,
+  IcLogoKakao,
+  IcLogoNaver,
+  IcMoreVertical,
+  IcPlus,
+  IcProfile,
+  IcSignUpDone,
+  IcStep1,
+  IcStep2,
+  IcStep3,
+  IcStep4,
+  IcSwap,
+  IcTextLogo,
+  IcTextLogoSmall,
+  IcUserGrey,
+};

--- a/src/assets/imgs/index.ts
+++ b/src/assets/imgs/index.ts
@@ -1,0 +1,8 @@
+import ImgChatEmpty from "./img_chat_empty.svg";
+import ImgFirstBanner from "./img_first_banner.svg";
+import ImgLogoBig from "./img_logo_big.svg";
+import ImgLogoSmall from "./img_logo_small.svg";
+import ImgSecondBanner from "./img_second_banner.svg";
+import ImgThirdBanner from "./img_third_banner.svg";
+
+export { ImgChatEmpty, ImgFirstBanner, ImgLogoBig, ImgLogoSmall, ImgSecondBanner, ImgThirdBanner };

--- a/src/components/Chat/ChatBottomSheet/ChatBottomSheet.tsx
+++ b/src/components/Chat/ChatBottomSheet/ChatBottomSheet.tsx
@@ -1,8 +1,5 @@
 import { ChatText } from "@/app/chat/page";
-import IcAirplaneGrey from "@/assets/icons/ic_airplane_grey.svg";
-import IcAirplaneMint from "@/assets/icons/ic_airplane_mint.svg";
-import IcCamera from "@/assets/icons/ic_camera.svg";
-import IcPlus from "@/assets/icons/ic_plus.svg";
+import { IcAirplaneGrey, IcAirplaneMint, IcCamera, IcPlus } from "@/assets/icons";
 import { IconButton } from "@/components/Common/IconButton";
 import { motion } from "framer-motion";
 import { useRef, useState, type ChangeEvent } from "react";

--- a/src/components/Chat/ChatBottomSheet/ChatBottomSheet.tsx
+++ b/src/components/Chat/ChatBottomSheet/ChatBottomSheet.tsx
@@ -1,11 +1,12 @@
-import * as styles from "./chatBottomSheet.css";
-import { useState, useRef, type ChangeEvent } from "react";
-import IcPlus from "@/assets/icons/ic_plus.svg";
-import IcAirplaneMint from "@/assets/icons/ic_airplane_mint.svg";
-import IcAirplaneGrey from "@/assets/icons/ic_airplane_grey.svg";
-import IcCamera from "@/assets/icons/ic_camera.svg";
-import { motion } from "framer-motion";
 import { ChatText } from "@/app/chat/page";
+import IcAirplaneGrey from "@/assets/icons/ic_airplane_grey.svg";
+import IcAirplaneMint from "@/assets/icons/ic_airplane_mint.svg";
+import IcCamera from "@/assets/icons/ic_camera.svg";
+import IcPlus from "@/assets/icons/ic_plus.svg";
+import { IconButton } from "@/components/Common/IconButton";
+import { motion } from "framer-motion";
+import { useRef, useState, type ChangeEvent } from "react";
+import * as styles from "./chatBottomSheet.css";
 
 interface ChatBottomSheetProps {
   isBottomSheetOpen: boolean;
@@ -58,9 +59,8 @@ export function ChatBottomSheet({
       transition={{ duration: 0.2 }}
     >
       <div className={styles.chatBottomSheetClosedSection}>
-        <button type="button" className={styles.openBottomSheetButton} onClick={handleClickPlusButton}>
-          <IcPlus />
-        </button>
+        {/* TODO: 카메라 버튼으로 변경 */}
+        <IconButton icon={<IcPlus />} label="바텀시트 열기 버튼" onClick={handleClickPlusButton} />
         <div className={styles.chattingInputBox}>
           <input
             className={styles.chattingInput}
@@ -69,9 +69,11 @@ export function ChatBottomSheet({
             onFocus={handleFocus}
             placeholder="메세지 보내기"
           />
-          <button type="button" onClick={handleClickSendButton}>
-            {chattingInputValue.length === 0 ? <IcAirplaneGrey /> : <IcAirplaneMint />}
-          </button>
+          <IconButton
+            icon={chattingInputValue.length === 0 ? <IcAirplaneGrey /> : <IcAirplaneMint />}
+            label="메시지 전송"
+            onClick={handleClickSendButton}
+          />
         </div>
       </div>
       {isBottomSheetOpen && (

--- a/src/components/Chat/MoreButton/MoreButton.tsx
+++ b/src/components/Chat/MoreButton/MoreButton.tsx
@@ -4,6 +4,8 @@ import IcMoreVertical from "@/assets/icons/ic_more_vertical.svg";
 
 const handleClickMoreButton = () => {};
 
+// TODO: 컴포넌트 분리 여부 검토
+
 export function MoreButton() {
   return (
     <button type="button" onClick={handleClickMoreButton}>

--- a/src/components/Chat/MoreButton/MoreButton.tsx
+++ b/src/components/Chat/MoreButton/MoreButton.tsx
@@ -1,15 +1,12 @@
 "use client";
 
-import IcMoreVertical from "@/assets/icons/ic_more_vertical.svg";
+import { IcMoreVertical } from "@/assets/icons";
+import { IconButton } from "@/components/Common/IconButton";
 
 const handleClickMoreButton = () => {};
 
 // TODO: 컴포넌트 분리 여부 검토
 
 export function MoreButton() {
-  return (
-    <button type="button" onClick={handleClickMoreButton}>
-      <IcMoreVertical />
-    </button>
-  );
+  return <IconButton icon={<IcMoreVertical />} label="더보기" onClick={handleClickMoreButton} />;
 }

--- a/src/components/Common/BackButton/BackButton.tsx
+++ b/src/components/Common/BackButton/BackButton.tsx
@@ -1,7 +1,7 @@
 "use client";
-import React from "react";
 import IcChevronLeft from "@/assets/icons/ic_chevron_left.svg";
 import { useRouter } from "next/navigation";
+import { IconButton } from "../IconButton";
 
 interface BackButtonProps {
   link?: string;
@@ -18,9 +18,5 @@ export function BackButton({ link }: BackButtonProps) {
     }
   };
 
-  return (
-    <button type="button" onClick={handleClickBackButton}>
-      <IcChevronLeft />
-    </button>
-  );
+  return <IconButton icon={<IcChevronLeft />} label="뒤로가기" onClick={handleClickBackButton} />;
 }

--- a/src/components/Common/BackButton/BackButton.tsx
+++ b/src/components/Common/BackButton/BackButton.tsx
@@ -1,5 +1,6 @@
 "use client";
-import IcChevronLeft from "@/assets/icons/ic_chevron_left.svg";
+
+import { IcChevronLeft } from "@/assets/icons";
 import { useRouter } from "next/navigation";
 import { IconButton } from "../IconButton";
 

--- a/src/components/Common/IconButton/index.tsx
+++ b/src/components/Common/IconButton/index.tsx
@@ -1,0 +1,14 @@
+import type { ButtonHTMLAttributes, ReactElement } from "react";
+
+interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  icon: ReactElement<SVGElement>;
+  label: string;
+}
+
+export function IconButton({ icon, label, ...props }: IconButtonProps) {
+  return (
+    <button type="button" aria-label={label} title={label} {...props}>
+      {icon}
+    </button>
+  );
+}

--- a/src/components/Common/IconButton/index.tsx
+++ b/src/components/Common/IconButton/index.tsx
@@ -1,14 +1,14 @@
-import type { ButtonHTMLAttributes, ReactElement } from "react";
+import { memo, type ButtonHTMLAttributes, type ReactElement } from "react";
 
 interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   icon: ReactElement<SVGElement>;
   label: string;
 }
 
-export function IconButton({ icon, label, ...props }: IconButtonProps) {
+export const IconButton = memo(function IconButton({ icon, label, ...props }: IconButtonProps) {
   return (
     <button type="button" aria-label={label} title={label} {...props}>
       {icon}
     </button>
   );
-}
+});

--- a/src/components/Common/NavBar/NavBar.tsx
+++ b/src/components/Common/NavBar/NavBar.tsx
@@ -1,18 +1,14 @@
 "use client";
 
+import { IcChatGrey, IcChatMint, IcHomeGrey, IcHomeMint, IcUserGrey } from "@/assets/icons";
+import Link from "next/link";
 import { usePathname } from "next/navigation";
 import * as styles from "./navBar.css";
-import Link from "next/link";
-
-import IcChatGrey from "@/assets/icons/ic_chat_grey.svg";
-import IcChatMint from "@/assets/icons/ic_chat_mint.svg";
-import IcHomeGrey from "@/assets/icons/ic_home_grey.svg";
-import IcHomeMint from "@/assets/icons/ic_home_mint.svg";
-import IcUserGrey from "@/assets/icons/ic_user_grey.svg";
 
 const navItems = [
   { href: "/home", label: "홈", icon: <IcHomeGrey />, activeIcon: <IcHomeMint /> },
   { href: "/chat-list", label: "채팅", icon: <IcChatGrey />, activeIcon: <IcChatMint /> },
+  // TODO: 마이페이지 activeIcon 문의
   { href: "/mypage", label: "마이페이지", icon: <IcUserGrey />, activeIcon: <IcUserGrey /> },
 ];
 

--- a/src/components/Common/Select/Select.tsx
+++ b/src/components/Common/Select/Select.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { createContext, useContext, useState, ReactNode, useEffect, useRef } from "react";
+import { IcChevronDown, IcChevronUp } from "@/assets/icons";
+import { createContext, ReactNode, useContext, useEffect, useRef, useState } from "react";
 import * as styles from "./Select.css";
-import IcChevronDown from "@/assets/icons/ic_chevron_down.svg";
-import IcChevronUp from "@/assets/icons/ic_chevron_up.svg";
 
 interface SelectContextType {
   selected: string;

--- a/src/components/Landing/FirstBanner/FirstBanner.tsx
+++ b/src/components/Landing/FirstBanner/FirstBanner.tsx
@@ -1,7 +1,7 @@
+import { IcTextLogo } from "@/assets/icons";
+import { ImgFirstBanner } from "@/assets/imgs";
 import { forwardRef } from "react";
 import * as styles from "./firstBanner.css";
-import IcTextLogo from "@/assets/icons/ic_text_logo.svg";
-import ImgFirstBanner from "@/assets/imgs/img_first_banner.svg";
 
 export const FirstBanner = forwardRef<HTMLDivElement>((_, ref) => {
   return (

--- a/src/components/Landing/SecondBanner/SecondBanner.tsx
+++ b/src/components/Landing/SecondBanner/SecondBanner.tsx
@@ -1,6 +1,6 @@
+import { ImgSecondBanner } from "@/assets/imgs";
 import { forwardRef } from "react";
 import * as styles from "./secondBanner.css";
-import ImgSecondBanner from "@/assets/imgs/img_second_banner.svg";
 
 export const SecondBanner = forwardRef<HTMLDivElement>((_, ref) => {
   return (

--- a/src/components/Landing/ThirdBanner/ThirdBanner.tsx
+++ b/src/components/Landing/ThirdBanner/ThirdBanner.tsx
@@ -1,7 +1,7 @@
+import { IcTextLogoSmall } from "@/assets/icons";
+import { ImgThirdBanner } from "@/assets/imgs";
 import { forwardRef } from "react";
 import * as styles from "./thirdBanner.css";
-import IcTextLogoSmall from "@/assets/icons/ic_text_logo_small.svg";
-import ImgThirdBanner from "@/assets/imgs/img_third_banner.svg";
 
 export const ThirdBanner = forwardRef<HTMLDivElement>((_, ref) => {
   return (

--- a/src/components/Login/LoginButtonSection.tsx
+++ b/src/components/Login/LoginButtonSection.tsx
@@ -1,9 +1,7 @@
 "use client";
 
+import { IcLogoGoogle, IcLogoKakao, IcLogoNaver } from "@/assets/icons";
 import * as styles from "./loginButtonSection.css";
-import IcLogoKakao from "@/assets/icons/ic_logo_kakao.svg";
-import IcLogoNaver from "@/assets/icons/ic_logo_naver.svg";
-import IcLogoGoogle from "@/assets/icons/ic_logo_google.svg";
 
 export function LoginButtonSection() {
   return (

--- a/src/components/SignUp/Info/ImageInputForm/ImageInputForm.tsx
+++ b/src/components/SignUp/Info/ImageInputForm/ImageInputForm.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import * as styles from "./ImageInputForm.css";
 import IcProfile from "@/assets/icons/ic_profile.svg";
+import { IconButton } from "@/components/Common/IconButton";
+import * as styles from "./ImageInputForm.css";
 
 function ImageInputForm() {
   return (
     <div className={styles.ImageInputFormWrapper}>
-      <button type="button">
-        <IcProfile />
-      </button>
+      <IconButton icon={<IcProfile />} label="프로필 사진 변경" />
     </div>
   );
 }

--- a/src/components/SignUp/Info/ImageInputForm/ImageInputForm.tsx
+++ b/src/components/SignUp/Info/ImageInputForm/ImageInputForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import IcProfile from "@/assets/icons/ic_profile.svg";
+import { IcProfile } from "@/assets/icons";
 import { IconButton } from "@/components/Common/IconButton";
 import * as styles from "./ImageInputForm.css";
 

--- a/src/components/SignUp/StepIcon/StepIcon.tsx
+++ b/src/components/SignUp/StepIcon/StepIcon.tsx
@@ -1,12 +1,8 @@
 "use client";
 
 import { memo } from "react";
-import IcStep1 from "@/assets/icons/ic_step1.svg";
-import IcStep2 from "@/assets/icons/ic_step2.svg";
-import IcStep3 from "@/assets/icons/ic_step3.svg";
-import IcStep4 from "@/assets/icons/ic_step4.svg";
-import IcCheckTransparent from "@/assets/icons/ic_check_transparent.svg";
-import IcGreyCircle from "@/assets/icons/ic_grey_circle.svg";
+
+import { IcCheckTransparent, IcGreyCircle, IcStep1, IcStep2, IcStep3, IcStep4 } from "@/assets/icons";
 import * as styles from "./stepIcon.css";
 
 interface StepIconProps {

--- a/src/components/SignUp/Terms/AllAgreeCheckboxField/AllAgreeCheckboxField.tsx
+++ b/src/components/SignUp/Terms/AllAgreeCheckboxField/AllAgreeCheckboxField.tsx
@@ -1,6 +1,6 @@
-import React, { memo } from "react";
-import IcCheckComplete from "@/assets/icons/ic_check_complete.svg";
-import IcCheckWhiteGrey from "@/assets/icons/ic_check_whitegrey.svg";
+import { memo } from "react";
+
+import { IcCheckComplete, IcCheckWhiteGrey } from "@/assets/icons";
 import * as styles from "./allAgreeCheckboxField.css";
 
 interface AllAgreeCheckboxProps {

--- a/src/components/SignUp/Terms/TermCheckboxField/TermCheckboxField.tsx
+++ b/src/components/SignUp/Terms/TermCheckboxField/TermCheckboxField.tsx
@@ -1,9 +1,7 @@
-import IcCheckGrey from "@/assets/icons/ic_check_grey.svg";
-import IcCheckMint from "@/assets/icons/ic_check_mint.svg";
-import IcArrowRight from "@/assets/icons/ic_arrow_right.svg";
-import * as styles from "./termCheckboxField.css";
+import { IcArrowRight, IcCheckGrey, IcCheckMint } from "@/assets/icons";
 import Link from "next/link";
 import { memo, useCallback } from "react";
+import * as styles from "./termCheckboxField.css";
 
 interface TermCheckboxProps {
   id: number;

--- a/src/components/SignUp/Univ/UnivInfoForm.tsx
+++ b/src/components/SignUp/Univ/UnivInfoForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import IcSwap from "@/assets/icons/ic_swap.svg";
+import { IcSwap } from "@/assets/icons";
 import Button from "@/components/Common/Button/Button";
 import { IconButton } from "@/components/Common/IconButton";
 import Select from "@/components/Common/Select/Select";

--- a/src/components/SignUp/Univ/UnivInfoForm.tsx
+++ b/src/components/SignUp/Univ/UnivInfoForm.tsx
@@ -1,11 +1,12 @@
 "use client";
 
+import IcSwap from "@/assets/icons/ic_swap.svg";
+import Button from "@/components/Common/Button/Button";
+import { IconButton } from "@/components/Common/IconButton";
+import Select from "@/components/Common/Select/Select";
+import TextField from "@/components/Common/TextField/TextField";
 import React, { useState } from "react";
 import * as styles from "./UnivInfoForm.css";
-import TextField from "@/components/Common/TextField/TextField";
-import IcSwap from "@/assets/icons/ic_swap.svg";
-import Select from "@/components/Common/Select/Select";
-import Button from "@/components/Common/Button/Button";
 
 function UnivInfoForm() {
   const [major, setMajor] = useState("");
@@ -29,9 +30,12 @@ function UnivInfoForm() {
           onChange={handleMajorChange}
           rightAddOn={
             major && (
-              <button type="button" onClick={handleResetMajor} className={styles.swapButton}>
-                <IcSwap />
-              </button>
+              <IconButton
+                icon={<IcSwap />}
+                label="학과 초기화"
+                onClick={handleResetMajor}
+                className={styles.swapButton}
+              />
             )
           }
         />


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #103

## ✅ 작업 내용
틴유 디자인에서는 Icon 형태의 버튼이 많이 사용돼요. 기존에는 `<button>` 내부에 SVGElement를 넣어서 다음과 같이 사용했습니다.
### AS-IS

```jsx
<button type="button" onClick={() => {}}>
  {icon}
</button>
```
요걸 더 직관적이고 간결하게 사용할 수 있도록 IconButton을 구현했어요.

### TO-BE

```jsx
<IconButton icon={icon} label="~~~" onClick={() => {}} />
```

웹 접근성 향상을 위해 `label` prop은 required prop입니다.

추가적으로 기존에는 asset import 시 자동완성이 되지 않아 불편하고 typo 이슈도 자주 발생해서 named export용 barrel file을 만들었어요.
barrel file의 단점은 미사용 asset까지 번들에 포함되는 점인데, 개선 방법을 더 고민해볼 예정입니다. 추후 asset 추가 시 자동으로 barrel file에 추가되는 watch 스크립트를 생성할 예정이에요.