### PR TITLE
feat: OptionButton 컴포넌트 구현

### DIFF
--- a/src/components/Common/OptionButton/index.tsx
+++ b/src/components/Common/OptionButton/index.tsx
@@ -1,0 +1,15 @@
+import { memo, type ButtonHTMLAttributes, type ReactNode } from "react";
+import * as styles from "./option-button.css";
+
+interface OptionButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: ReactNode;
+  isSelected?: boolean;
+}
+
+export const OptionButton = memo(function OptionButton({ children, isSelected = false, ...props }: OptionButtonProps) {
+  return (
+    <button type="button" {...props} className={styles.optionButtonStyle({ isSelected })}>
+      {children}
+    </button>
+  );
+});

--- a/src/components/Common/OptionButton/option-button.css.ts
+++ b/src/components/Common/OptionButton/option-button.css.ts
@@ -1,0 +1,29 @@
+import { vars } from "@/styles/theme.css";
+import { recipe } from "@vanilla-extract/recipes";
+
+export const optionButtonStyle = recipe({
+  base: {
+    width: "100%",
+    height: "5rem",
+
+    ...vars.fontStyles.body2_m_14,
+
+    borderRadius: "0.85rem",
+    background: vars.color.mint_500,
+  },
+  variants: {
+    isSelected: {
+      true: {
+        color: vars.color.mint_500,
+
+        backgroundColor: vars.color.mint_50,
+        boxShadow: `inset 0 0 0 1px ${vars.color.mint_500}`,
+      },
+      false: {
+        color: vars.color.grey_12,
+
+        backgroundColor: vars.color.grey_2,
+      },
+    },
+  },
+});


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #112 

## ✅ 작업 내용

OptionButton 공통 컴포넌트를 구현했어요.
'isSelected' prop으로 선택 여부를 제어할 수 있어요.

하단 스크린샷에서 왼쪽이 선택 상태, 오른쪽이 미선택 상태 버튼입니다!

## 📸 스크린샷 / GIF / Link
<img width="351" height="57" alt="image" src="https://github.com/user-attachments/assets/00dafc04-27b2-4d41-a87f-f7828c9d210c" />