### PR TITLE
feat: 탈퇴하기 페이지 퍼블리싱(마지막 단계 제외)

### DIFF
--- a/src/app/delete-account/delete-account.css.ts
+++ b/src/app/delete-account/delete-account.css.ts
@@ -29,11 +29,13 @@ export const withdrawInfoWrapper = style({
 });
 
 export const withdrawInfo = style({
+  margin: "2rem 0",
+});
+
+export const withdrawBox = style({
   display: "flex",
   alignItems: "center",
   gap: "1rem",
-
-  margin: "2rem 0",
 });
 
 export const withdrawInfoText = style({
@@ -42,14 +44,22 @@ export const withdrawInfoText = style({
 });
 
 export const verticalLine = style({
-  marginLeft: "2rem",
+  width: "0.4rem",
   height: "7rem",
+  borderRadius: "1.2rem",
+
+  backgroundColor: "#D9D9D9",
+
+  marginLeft: "2rem",
+  flexShrink: "0",
 });
 
 export const withdrawDescription = style({
   display: "flex",
   alignItems: "center",
   gap: "1rem",
+
+  marginTop: "2rem",
 });
 
 export const withdrawDescriptionText = style({

--- a/src/app/delete-account/delete-account.css.ts
+++ b/src/app/delete-account/delete-account.css.ts
@@ -57,7 +57,7 @@ export const verticalLine = style({
 export const withdrawDescription = style({
   display: "flex",
   alignItems: "center",
-  gap: "1rem",
+  gap: "1.3rem",
 
   marginTop: "2rem",
 });

--- a/src/app/delete-account/delete-account.css.ts
+++ b/src/app/delete-account/delete-account.css.ts
@@ -1,0 +1,76 @@
+import { vars } from "@/styles/theme.css";
+import { style } from "@vanilla-extract/css";
+
+export const withdrawTextWrapper = style({
+  width: "100%",
+  height: "100%",
+
+  padding: "3rem",
+});
+
+export const headerText = style({
+  ...vars.fontStyles.subtitle1_sb_16,
+  color: vars.color.grey_12,
+});
+
+export const titleWrapper = style({
+  ...vars.fontStyles.title2_sb_22,
+});
+
+export const descriptionWrapper = style({
+  ...vars.fontStyles.body2_m_14,
+  color: vars.color.grey_6,
+
+  marginTop: "0.5rem",
+});
+
+export const withdrawInfoWrapper = style({
+  padding: "0 3rem",
+});
+
+export const withdrawInfo = style({
+  display: "flex",
+  alignItems: "center",
+  gap: "1rem",
+
+  margin: "2rem 0",
+});
+
+export const withdrawInfoText = style({
+  ...vars.fontStyles.body2_m_14,
+  color: vars.color.grey_10,
+});
+
+export const verticalLine = style({
+  marginLeft: "2rem",
+  height: "7rem",
+});
+
+export const withdrawDescription = style({
+  display: "flex",
+  alignItems: "center",
+  gap: "1rem",
+});
+
+export const withdrawDescriptionText = style({
+  ...vars.fontStyles.label1_m_12,
+  color: vars.color.grey_6,
+});
+
+export const descriptionFlex = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: "2rem",
+});
+
+export const fixedButtonWrapper = style({
+  display: "flex",
+  gap: "1.2rem",
+
+  position: "fixed",
+  bottom: "3.4rem",
+  left: "0",
+  right: "0",
+
+  padding: "0 2rem",
+});

--- a/src/app/delete-account/delete-account.css.ts
+++ b/src/app/delete-account/delete-account.css.ts
@@ -13,11 +13,11 @@ export const headerText = style({
   color: vars.color.grey_12,
 });
 
-export const titleWrapper = style({
+export const title = style({
   ...vars.fontStyles.title2_sb_22,
 });
 
-export const descriptionWrapper = style({
+export const description = style({
   ...vars.fontStyles.body2_m_14,
   color: vars.color.grey_6,
 

--- a/src/app/delete-account/page.tsx
+++ b/src/app/delete-account/page.tsx
@@ -3,8 +3,7 @@
 import { BackButton } from "@/components/Common/BackButton/BackButton";
 import { Header } from "@/components/Common/Header/Header";
 import * as styles from "./delete-account.css";
-import { IconButton } from "@/components/Common/IconButton";
-import { IcCheckComplete, IcVerticalLine } from "@/assets/icons";
+import { IcCheckCompleteSmall } from "@/assets/icons";
 import Button from "@/components/Common/Button/Button";
 import { useRouter } from "next/navigation";
 import { useCallback } from "react";
@@ -12,7 +11,7 @@ import { useCallback } from "react";
 export default function page() {
   const router = useRouter();
   const handleClickDeleteAccount = useCallback(() => {
-    router.push("delete-account/reason");
+    router.push("/delete-account/reason");
   }, [router]);
 
   return (
@@ -23,29 +22,33 @@ export default function page() {
         <h2 className={styles.description}>잠깐! 틴유를 탈퇴하기 전에 하단 정보를 확인해주세요.</h2>
       </div>
 
-      <div className={styles.withdrawInfoWrapper}>
-        <div className={styles.withdrawInfo}>
-          <IconButton icon={<IcCheckComplete />} label="체크 버튼" />
-          <span className={styles.withdrawInfoText}>
-            아래 항목을 포함한 모든 정보가 영구적으로 삭제되며 복구할 수 없습니다.
-          </span>
-        </div>
-
-        <div className={styles.withdrawDescription}>
-          <IcVerticalLine className={styles.verticalLine} />
-          <div className={styles.descriptionFlex}>
-            <span className={styles.withdrawDescriptionText}>글, 프로필 등 모든 사용자 정보</span>
-            <span className={styles.withdrawDescriptionText}>
-              타인의 게시물에 단 댓글은 삭제되지 않으니 미리 확인하세요.
+      <article className={styles.withdrawInfoWrapper}>
+        <section className={styles.withdrawInfo}>
+          <div className={styles.withdrawBox}>
+            <IcCheckCompleteSmall />
+            <span className={styles.withdrawInfoText}>
+              아래 항목을 포함한 모든 정보가 영구적으로 삭제
+              <br />
+              되며 복구할 수 없습니다.
             </span>
           </div>
-        </div>
 
-        <div className={styles.withdrawInfo}>
-          <IconButton icon={<IcCheckComplete />} label="체크 버튼" />
+          <div className={styles.withdrawDescription}>
+            <div className={styles.verticalLine} />
+            <div className={styles.descriptionFlex}>
+              <span className={styles.withdrawDescriptionText}>글, 프로필 등 모든 사용자 정보</span>
+              <span className={styles.withdrawDescriptionText}>
+                타인의 게시물에 단 댓글은 삭제되지 않으니 미리 확인하세요.
+              </span>
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.withdrawBox}>
+          <IcCheckCompleteSmall />
           <span className={styles.withdrawInfoText}>탈퇴 후 7일 간 재가입이 불가능합니다.</span>
-        </div>
-      </div>
+        </section>
+      </article>
 
       <div className={styles.fixedButtonWrapper}>
         <Button onClick={handleClickDeleteAccount}>탈퇴하기</Button>

--- a/src/app/delete-account/page.tsx
+++ b/src/app/delete-account/page.tsx
@@ -19,8 +19,8 @@ export default function page() {
     <>
       <Header isSticky left={<BackButton />} />
       <div className={styles.withdrawTextWrapper}>
-        <h1 className={styles.titleWrapper}>떠나시는 건가요?</h1>
-        <h2 className={styles.descriptionWrapper}>잠깐! 틴유를 탈퇴하기 전에 하단 정보를 확인해주세요.</h2>
+        <h1 className={styles.title}>떠나시는 건가요?</h1>
+        <h2 className={styles.description}>잠깐! 틴유를 탈퇴하기 전에 하단 정보를 확인해주세요.</h2>
       </div>
 
       <div className={styles.withdrawInfoWrapper}>

--- a/src/app/delete-account/page.tsx
+++ b/src/app/delete-account/page.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { BackButton } from "@/components/Common/BackButton/BackButton";
+import { Header } from "@/components/Common/Header/Header";
+import * as styles from "./delete-account.css";
+import { IconButton } from "@/components/Common/IconButton";
+import { IcCheckComplete, IcVerticalLine } from "@/assets/icons";
+import Button from "@/components/Common/Button/Button";
+import { useRouter } from "next/navigation";
+import { useCallback } from "react";
+
+export default function page() {
+  const router = useRouter();
+  const handleClickDeleteAccount = useCallback(() => {
+    router.push("delete-account/reason");
+  }, [router]);
+
+  return (
+    <>
+      <Header isSticky left={<BackButton />} />
+      <div className={styles.withdrawTextWrapper}>
+        <h1 className={styles.titleWrapper}>떠나시는 건가요?</h1>
+        <h2 className={styles.descriptionWrapper}>잠깐! 틴유를 탈퇴하기 전에 하단 정보를 확인해주세요.</h2>
+      </div>
+
+      <div className={styles.withdrawInfoWrapper}>
+        <div className={styles.withdrawInfo}>
+          <IconButton icon={<IcCheckComplete />} label="체크 버튼" />
+          <span className={styles.withdrawInfoText}>
+            아래 항목을 포함한 모든 정보가 영구적으로 삭제되며 복구할 수 없습니다.
+          </span>
+        </div>
+
+        <div className={styles.withdrawDescription}>
+          <IcVerticalLine className={styles.verticalLine} />
+          <div className={styles.descriptionFlex}>
+            <span className={styles.withdrawDescriptionText}>글, 프로필 등 모든 사용자 정보</span>
+            <span className={styles.withdrawDescriptionText}>
+              타인의 게시물에 단 댓글은 삭제되지 않으니 미리 확인하세요.
+            </span>
+          </div>
+        </div>
+
+        <div className={styles.withdrawInfo}>
+          <IconButton icon={<IcCheckComplete />} label="체크 버튼" />
+          <span className={styles.withdrawInfoText}>탈퇴 후 7일 간 재가입이 불가능합니다.</span>
+        </div>
+      </div>
+
+      <div className={styles.fixedButtonWrapper}>
+        <Button onClick={handleClickDeleteAccount}>탈퇴하기</Button>
+        <Button>계속 이용하기</Button>
+      </div>
+    </>
+  );
+}

--- a/src/app/delete-account/page.tsx
+++ b/src/app/delete-account/page.tsx
@@ -38,7 +38,7 @@ export default function page() {
             <div className={styles.descriptionFlex}>
               <span className={styles.withdrawDescriptionText}>글, 프로필 등 모든 사용자 정보</span>
               <span className={styles.withdrawDescriptionText}>
-                타인의 게시물에 단 댓글은 삭제되지 않으니 미리 확인하세요.
+                타인 게시물의 댓글은 삭제되지 않으니 미리 확인하세요.
               </span>
             </div>
           </div>

--- a/src/app/delete-account/reason/page.tsx
+++ b/src/app/delete-account/reason/page.tsx
@@ -1,0 +1,22 @@
+import { Header } from "@/components/Common/Header/Header";
+import * as styles from "./reason.css";
+import { BackButton } from "@/components/Common/BackButton/BackButton";
+import DeleteAccountReasonForm from "@/components/reason/DeleteAccountReasonForm";
+
+export default function page() {
+  return (
+    <>
+      <Header isSticky left={<BackButton />} />
+      <div className={styles.reportTextWrapper}>
+        <h1 className={styles.titleWrapper}>
+          떠나시는 이유를
+          <br />
+          알려주실 수 있나요?
+        </h1>
+        <h2 className={styles.descriptionWrapper}>탈퇴 후 7일 동안 다시 가입할 수 없어요.</h2>
+      </div>
+
+      <DeleteAccountReasonForm />
+    </>
+  );
+}

--- a/src/app/delete-account/reason/reason.css.ts
+++ b/src/app/delete-account/reason/reason.css.ts
@@ -1,0 +1,25 @@
+import { vars } from "@/styles/theme.css";
+import { style } from "@vanilla-extract/css";
+
+export const reportTextWrapper = style({
+  width: "100%",
+  height: "100%",
+
+  padding: "3rem",
+});
+
+export const headerText = style({
+  ...vars.fontStyles.subtitle1_sb_16,
+  color: vars.color.grey_12,
+});
+
+export const titleWrapper = style({
+  ...vars.fontStyles.title2_sb_22,
+});
+
+export const descriptionWrapper = style({
+  ...vars.fontStyles.body2_m_14,
+  color: vars.color.grey_6,
+
+  marginTop: "0.5rem",
+});

--- a/src/assets/icons/ic_check_complete_small.svg
+++ b/src/assets/icons/ic_check_complete_small.svg
@@ -1,0 +1,11 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_6024_5020)">
+<circle cx="10" cy="10" r="10" fill="#14C3BC"/>
+<path d="M5 10.2016L8.53553 13.7371L15.6058 6.66602" stroke="white" stroke-width="1.66667" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_6024_5020">
+<rect width="20" height="20" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -5,6 +5,7 @@ import IcCamera from "./ic_camera.svg";
 import IcChatGrey from "./ic_chat_grey.svg";
 import IcChatBlack from "./ic_chat_black.svg";
 import IcCheckComplete from "./ic_check_complete.svg";
+import IcCheckCompleteSmall from "./ic_check_complete_small.svg";
 import IcCheckGrey from "./ic_check_grey.svg";
 import IcCheckMint from "./ic_check_mint.svg";
 import IcCheckTransparent from "./ic_check_transparent.svg";
@@ -55,6 +56,7 @@ export {
   IcChatGrey,
   IcChatBlack,
   IcCheckComplete,
+  IcCheckCompleteSmall,
   IcCheckGrey,
   IcCheckMint,
   IcCheckTransparent,

--- a/src/components/Common/Select/Select.tsx
+++ b/src/components/Common/Select/Select.tsx
@@ -5,9 +5,10 @@ import { createContext, ReactNode, useContext, useEffect, useRef, useState } fro
 import * as styles from "./Select.css";
 
 interface SelectContextType {
-  selected: string;
+  selectedValue: string;
+  selectedLabel: string;
   isOpen: boolean;
-  setSelected: (value: string) => void;
+  setSelected: (value: string, label: string) => void;
   toggleDropdown: () => void;
   closeDropdown: () => void;
   placeholder?: string;
@@ -23,11 +24,13 @@ interface SelectRootProps {
 }
 
 function SelectRoot({ children, onSelect, placeholder }: SelectRootProps) {
-  const [selected, setSelectedState] = useState("");
+  const [selectedValue, setSelectedValue] = useState("");
+  const [selectedLabel, setSelectedLabel] = useState("");
   const [isOpen, setIsOpen] = useState(false);
 
-  const setSelected = (value: string) => {
-    setSelectedState(value);
+  const setSelected = (value: string, label: string) => {
+    setSelectedValue(value);
+    setSelectedLabel(label);
     onSelect?.(value);
     setIsOpen(false);
   };
@@ -36,7 +39,17 @@ function SelectRoot({ children, onSelect, placeholder }: SelectRootProps) {
   const closeDropdown = () => setIsOpen(false);
 
   return (
-    <SelectContext.Provider value={{ selected, isOpen, setSelected, toggleDropdown, closeDropdown, placeholder }}>
+    <SelectContext.Provider
+      value={{
+        selectedValue,
+        selectedLabel,
+        isOpen,
+        setSelected,
+        toggleDropdown,
+        closeDropdown,
+        placeholder,
+      }}
+    >
       <div className={styles.dropdownWrapper}>{children}</div>
     </SelectContext.Provider>
   );
@@ -47,11 +60,11 @@ function Trigger() {
   const context = useContext(SelectContext);
   if (!context) throw new Error("Select.Trigger must be used within Select");
 
-  const { selected, isOpen, toggleDropdown, placeholder } = context;
+  const { selectedLabel, isOpen, toggleDropdown, placeholder } = context;
 
   return (
     <div className={styles.selectBox({ isOpen })} onClick={toggleDropdown}>
-      <span className={styles.placeholderText({ isSelected: !!selected })}>{selected || placeholder}</span>
+      <span className={styles.placeholderText({ isSelected: !!selectedLabel })}>{selectedLabel || placeholder}</span>
       {isOpen ? <IcChevronUp /> : <IcChevronDown />}
     </div>
   );
@@ -81,7 +94,11 @@ function Main({ children }: { children: ReactNode }) {
 
   if (!isOpen) return null;
 
-  return <ul className={styles.dropdownList}>{children}</ul>;
+  return (
+    <ul className={styles.dropdownList} ref={ref}>
+      {children}
+    </ul>
+  );
 }
 
 // 4. Select.Option
@@ -92,7 +109,7 @@ function Option({ value, children }: { value: string; children: ReactNode }) {
   const { setSelected } = context;
 
   return (
-    <li className={styles.dropdownItem} onClick={() => setSelected(value)}>
+    <li className={styles.dropdownItem} onClick={() => setSelected(value, String(children))}>
       {children}
     </li>
   );

--- a/src/components/Common/Select/Select.tsx
+++ b/src/components/Common/Select/Select.tsx
@@ -5,10 +5,9 @@ import { createContext, ReactNode, useContext, useEffect, useRef, useState } fro
 import * as styles from "./Select.css";
 
 interface SelectContextType {
-  selectedValue: string;
-  selectedLabel: string;
+  selected: string;
   isOpen: boolean;
-  setSelected: (value: string, label: string) => void;
+  setSelected: (value: string) => void;
   toggleDropdown: () => void;
   closeDropdown: () => void;
   placeholder?: string;
@@ -24,13 +23,11 @@ interface SelectRootProps {
 }
 
 function SelectRoot({ children, onSelect, placeholder }: SelectRootProps) {
-  const [selectedValue, setSelectedValue] = useState("");
-  const [selectedLabel, setSelectedLabel] = useState("");
+  const [selected, setSelectedState] = useState("");
   const [isOpen, setIsOpen] = useState(false);
 
-  const setSelected = (value: string, label: string) => {
-    setSelectedValue(value);
-    setSelectedLabel(label);
+  const setSelected = (value: string) => {
+    setSelectedState(value);
     onSelect?.(value);
     setIsOpen(false);
   };
@@ -39,17 +36,7 @@ function SelectRoot({ children, onSelect, placeholder }: SelectRootProps) {
   const closeDropdown = () => setIsOpen(false);
 
   return (
-    <SelectContext.Provider
-      value={{
-        selectedValue,
-        selectedLabel,
-        isOpen,
-        setSelected,
-        toggleDropdown,
-        closeDropdown,
-        placeholder,
-      }}
-    >
+    <SelectContext.Provider value={{ selected, isOpen, setSelected, toggleDropdown, closeDropdown, placeholder }}>
       <div className={styles.dropdownWrapper}>{children}</div>
     </SelectContext.Provider>
   );
@@ -60,11 +47,11 @@ function Trigger() {
   const context = useContext(SelectContext);
   if (!context) throw new Error("Select.Trigger must be used within Select");
 
-  const { selectedLabel, isOpen, toggleDropdown, placeholder } = context;
+  const { selected, isOpen, toggleDropdown, placeholder } = context;
 
   return (
     <div className={styles.selectBox({ isOpen })} onClick={toggleDropdown}>
-      <span className={styles.placeholderText({ isSelected: !!selectedLabel })}>{selectedLabel || placeholder}</span>
+      <span className={styles.placeholderText({ isSelected: !!selected })}>{selected || placeholder}</span>
       {isOpen ? <IcChevronUp /> : <IcChevronDown />}
     </div>
   );
@@ -94,11 +81,7 @@ function Main({ children }: { children: ReactNode }) {
 
   if (!isOpen) return null;
 
-  return (
-    <ul className={styles.dropdownList} ref={ref}>
-      {children}
-    </ul>
-  );
+  return <ul className={styles.dropdownList}>{children}</ul>;
 }
 
 // 4. Select.Option
@@ -109,7 +92,7 @@ function Option({ value, children }: { value: string; children: ReactNode }) {
   const { setSelected } = context;
 
   return (
-    <li className={styles.dropdownItem} onClick={() => setSelected(value, String(children))}>
+    <li className={styles.dropdownItem} onClick={() => setSelected(value)}>
       {children}
     </li>
   );

--- a/src/components/reason/DeleteAccountReasonForm.tsx
+++ b/src/components/reason/DeleteAccountReasonForm.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import React, { useState } from "react";
+import Select from "../Common/Select/Select";
+import * as styles from "./deleteAccountReasonForm.css";
+import Button from "../Common/Button/Button";
+
+function DeleteAccountReasonForm() {
+  const [reason, setReason] = useState("");
+  const [guitarReason, setGuitarReason] = useState("");
+
+  const handleReasonSelect = (value: string) => {
+    setReason(value);
+    setGuitarReason("");
+  };
+
+  const isGuitar = reason === "기타 사유 (직접 입력)";
+  const isValid = isGuitar ? !!guitarReason.trim() : !!reason;
+
+  return (
+    <>
+      <form className={styles.reportSelectWrapper}>
+        <Select placeholder="해당하는 내용을 선택하세요" onSelect={handleReasonSelect}>
+          <Select.Trigger />
+          <Select.Main>
+            <Select.Option value="사고 싶은 물품이 없어요">사고 싶은 물품이 없어요</Select.Option>
+            <Select.Option value="물품이 안 팔려요">물품이 안 팔려요</Select.Option>
+            <Select.Option value="비매너 사용자를 만났어요">비매너 사용자를 만났어요</Select.Option>
+            <Select.Option value="새 계정을 만들고 싶어요">새 계정을 만들고 싶어요</Select.Option>
+            <Select.Option value="기타 사유 (직접 입력)">기타 사유 (직접 입력)</Select.Option>
+          </Select.Main>
+        </Select>
+
+        {isGuitar && (
+          <textarea
+            placeholder="자세한 내용을 입력해주세요"
+            value={guitarReason}
+            onChange={(e) => setGuitarReason(e.target.value)}
+            className={styles.guitarReasonTextarea}
+          />
+        )}
+      </form>
+
+      <div className={styles.fixedButtonWrapper}>
+        <Button disabled={!isValid}>탈퇴하기</Button>
+      </div>
+    </>
+  );
+}
+
+export default DeleteAccountReasonForm;

--- a/src/components/reason/DeleteAccountReasonForm.tsx
+++ b/src/components/reason/DeleteAccountReasonForm.tsx
@@ -5,15 +5,15 @@ import Select from "../Common/Select/Select";
 import * as styles from "./deleteAccountReasonForm.css";
 import Button from "../Common/Button/Button";
 
-function DeleteAccountReasonForm() {
-  const 탈퇴사유 = {
-    noProduct: "사고 싶은 물품이 없어요",
-    notSell: "물품이 안 팔려요",
-    noMannerUser: "비매너 사용자를 만났어요",
-    newAccount: "새 계정을 만들고 싶어요",
-    elseReason: "기타 사유 (직접 입력)",
-  } as const;
+const 탈퇴사유 = {
+  noProduct: "사고 싶은 물품이 없어요",
+  notSell: "물품이 안 팔려요",
+  noMannerUser: "비매너 사용자를 만났어요",
+  newAccount: "새 계정을 만들고 싶어요",
+  elseReason: "기타 사유 (직접 입력)",
+} as const;
 
+function DeleteAccountReasonForm() {
   const [reason, setReason] = useState<(typeof 탈퇴사유)[keyof typeof 탈퇴사유] | null>(null);
   const [guitarReason, setGuitarReason] = useState("");
 

--- a/src/components/reason/DeleteAccountReasonForm.tsx
+++ b/src/components/reason/DeleteAccountReasonForm.tsx
@@ -14,15 +14,15 @@ function DeleteAccountReasonForm() {
     elseReason: "기타 사유 (직접 입력)",
   } as const;
 
-  const [reason, setReason] = useState<keyof typeof 탈퇴사유 | null>(null);
+  const [reason, setReason] = useState<(typeof 탈퇴사유)[keyof typeof 탈퇴사유] | null>(null);
   const [guitarReason, setGuitarReason] = useState("");
 
   const handleReasonSelect = (value: string) => {
-    setReason(value as keyof typeof 탈퇴사유);
+    setReason(value as (typeof 탈퇴사유)[keyof typeof 탈퇴사유]);
     setGuitarReason("");
   };
 
-  const isGuitar = reason === "elseReason";
+  const isGuitar = reason === 탈퇴사유.elseReason;
   const isValid = isGuitar ? !!guitarReason.trim() : !!reason;
 
   return (
@@ -32,7 +32,7 @@ function DeleteAccountReasonForm() {
           <Select.Trigger />
           <Select.Main>
             {Object.entries(탈퇴사유).map(([key, label]) => (
-              <Select.Option key={key} value={key}>
+              <Select.Option key={key} value={label}>
                 {label}
               </Select.Option>
             ))}

--- a/src/components/reason/DeleteAccountReasonForm.tsx
+++ b/src/components/reason/DeleteAccountReasonForm.tsx
@@ -6,15 +6,23 @@ import * as styles from "./deleteAccountReasonForm.css";
 import Button from "../Common/Button/Button";
 
 function DeleteAccountReasonForm() {
-  const [reason, setReason] = useState("");
+  const 탈퇴사유 = {
+    noProduct: "사고 싶은 물품이 없어요",
+    notSell: "물품이 안 팔려요",
+    noMannerUser: "비매너 사용자를 만났어요",
+    newAccount: "새 계정을 만들고 싶어요",
+    elseReason: "기타 사유 (직접 입력)",
+  } as const;
+
+  const [reason, setReason] = useState<keyof typeof 탈퇴사유 | null>(null);
   const [guitarReason, setGuitarReason] = useState("");
 
   const handleReasonSelect = (value: string) => {
-    setReason(value);
+    setReason(value as keyof typeof 탈퇴사유);
     setGuitarReason("");
   };
 
-  const isGuitar = reason === "기타 사유 (직접 입력)";
+  const isGuitar = reason === "elseReason";
   const isValid = isGuitar ? !!guitarReason.trim() : !!reason;
 
   return (
@@ -23,11 +31,11 @@ function DeleteAccountReasonForm() {
         <Select placeholder="해당하는 내용을 선택하세요" onSelect={handleReasonSelect}>
           <Select.Trigger />
           <Select.Main>
-            <Select.Option value="사고 싶은 물품이 없어요">사고 싶은 물품이 없어요</Select.Option>
-            <Select.Option value="물품이 안 팔려요">물품이 안 팔려요</Select.Option>
-            <Select.Option value="비매너 사용자를 만났어요">비매너 사용자를 만났어요</Select.Option>
-            <Select.Option value="새 계정을 만들고 싶어요">새 계정을 만들고 싶어요</Select.Option>
-            <Select.Option value="기타 사유 (직접 입력)">기타 사유 (직접 입력)</Select.Option>
+            {Object.entries(탈퇴사유).map(([key, label]) => (
+              <Select.Option key={key} value={key}>
+                {label}
+              </Select.Option>
+            ))}
           </Select.Main>
         </Select>
 

--- a/src/components/reason/deleteAccountReasonForm.css.ts
+++ b/src/components/reason/deleteAccountReasonForm.css.ts
@@ -15,7 +15,6 @@ export const guitarReasonTextarea = style({
   width: "100%",
   height: "14rem",
 
-  // fontFamily: "var(--font-pretendard)",
   ...vars.fontStyles.subtitle3_r_16,
   backgroundColor: vars.color.grey_2,
   border: `1px solid ${vars.color.grey_4}`,

--- a/src/components/reason/deleteAccountReasonForm.css.ts
+++ b/src/components/reason/deleteAccountReasonForm.css.ts
@@ -1,0 +1,38 @@
+import { vars } from "@/styles/theme.css";
+import { style } from "@vanilla-extract/css";
+
+export const reportSelectWrapper = style({
+  width: "100%",
+  height: "100%",
+
+  display: "flex",
+  flexDirection: "column",
+
+  padding: "0 2rem",
+});
+
+export const guitarReasonTextarea = style({
+  width: "100%",
+  height: "14rem",
+
+  // fontFamily: "var(--font-pretendard)",
+  ...vars.fontStyles.subtitle3_r_16,
+  backgroundColor: vars.color.grey_2,
+  border: `1px solid ${vars.color.grey_4}`,
+  borderRadius: "1rem",
+
+  padding: "1.5rem",
+  marginTop: "1rem",
+
+  resize: "none",
+  outline: "none",
+});
+
+export const fixedButtonWrapper = style({
+  position: "fixed",
+  bottom: "3.4rem",
+  left: "0",
+  right: "0",
+
+  padding: "0 2rem",
+});

--- a/src/components/report/ReportReasonForm.tsx
+++ b/src/components/report/ReportReasonForm.tsx
@@ -14,15 +14,15 @@ function ReportReasonForm() {
     elseReason: "기타 사유 (직접 입력)",
   } as const;
 
-  const [reason, setReason] = useState<keyof typeof 신고사유 | null>(null);
+  const [reason, setReason] = useState<(typeof 신고사유)[keyof typeof 신고사유] | null>(null);
   const [guitarReason, setGuitarReason] = useState("");
 
   const handleReasonSelect = (value: string) => {
-    setReason(value as keyof typeof 신고사유);
+    setReason(value as (typeof 신고사유)[keyof typeof 신고사유]);
     setGuitarReason("");
   };
 
-  const isGuitar = reason === "elseReason";
+  const isGuitar = reason === 신고사유.elseReason;
   const isValid = isGuitar ? !!guitarReason.trim() : !!reason;
 
   return (
@@ -32,7 +32,7 @@ function ReportReasonForm() {
           <Select.Trigger />
           <Select.Main>
             {Object.entries(신고사유).map(([key, label]) => (
-              <Select.Option key={key} value={key}>
+              <Select.Option key={key} value={label}>
                 {label}
               </Select.Option>
             ))}

--- a/src/components/report/ReportReasonForm.tsx
+++ b/src/components/report/ReportReasonForm.tsx
@@ -5,15 +5,15 @@ import Select from "../Common/Select/Select";
 import * as styles from "./reportReasonForm.css";
 import Button from "../Common/Button/Button";
 
-function ReportReasonForm() {
-  const 신고사유 = {
-    mismatchInfo: "상품 정보가 실제와 달라요",
-    noShow: "거래 약속을 지키지 않았어요",
-    abusiveUser: "욕설이나 비하 발언을 했어요",
-    suspicious: "사기가 의심돼요",
-    elseReason: "기타 사유 (직접 입력)",
-  } as const;
+const 신고사유 = {
+  mismatchInfo: "상품 정보가 실제와 달라요",
+  noShow: "거래 약속을 지키지 않았어요",
+  abusiveUser: "욕설이나 비하 발언을 했어요",
+  suspicious: "사기가 의심돼요",
+  elseReason: "기타 사유 (직접 입력)",
+} as const;
 
+function ReportReasonForm() {
   const [reason, setReason] = useState<(typeof 신고사유)[keyof typeof 신고사유] | null>(null);
   const [guitarReason, setGuitarReason] = useState("");
 

--- a/src/components/report/ReportReasonForm.tsx
+++ b/src/components/report/ReportReasonForm.tsx
@@ -6,15 +6,23 @@ import * as styles from "./reportReasonForm.css";
 import Button from "../Common/Button/Button";
 
 function ReportReasonForm() {
-  const [reason, setReason] = useState("");
+  const 신고사유 = {
+    mismatchInfo: "상품 정보가 실제와 달라요",
+    noShow: "거래 약속을 지키지 않았어요",
+    abusiveUser: "욕설이나 비하 발언을 했어요",
+    suspicious: "사기가 의심돼요",
+    elseReason: "기타 사유 (직접 입력)",
+  } as const;
+
+  const [reason, setReason] = useState<keyof typeof 신고사유 | null>(null);
   const [guitarReason, setGuitarReason] = useState("");
 
   const handleReasonSelect = (value: string) => {
-    setReason(value);
+    setReason(value as keyof typeof 신고사유);
     setGuitarReason("");
   };
 
-  const isGuitar = reason === "기타 사유 (직접 입력)";
+  const isGuitar = reason === "elseReason";
   const isValid = isGuitar ? !!guitarReason.trim() : !!reason;
 
   return (
@@ -23,11 +31,11 @@ function ReportReasonForm() {
         <Select placeholder="해당하는 내용을 선택하세요" onSelect={handleReasonSelect}>
           <Select.Trigger />
           <Select.Main>
-            <Select.Option value="상품 정보가 실제와 달라요">상품 정보가 실제와 달라요</Select.Option>
-            <Select.Option value="거래 약속을 지키지 않았어요">거래 약속을 지키지 않았어요</Select.Option>
-            <Select.Option value="욕설이나 비하 발언을 했어요">욕설이나 비하 발언을 했어요</Select.Option>
-            <Select.Option value="사기가 의심돼요">사기가 의심돼요</Select.Option>
-            <Select.Option value="기타 사유 (직접 입력)">기타 사유 (직접 입력)</Select.Option>
+            {Object.entries(신고사유).map(([key, label]) => (
+              <Select.Option key={key} value={key}>
+                {label}
+              </Select.Option>
+            ))}
           </Select.Main>
         </Select>
 

--- a/src/components/report/reportReasonForm.css.ts
+++ b/src/components/report/reportReasonForm.css.ts
@@ -15,7 +15,6 @@ export const guitarReasonTextarea = style({
   width: "100%",
   height: "14rem",
 
-  // fontFamily: "var(--font-pretendard)",
   ...vars.fontStyles.subtitle3_r_16,
   backgroundColor: vars.color.grey_2,
   border: `1px solid ${vars.color.grey_4}`,


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #119 

## ✅ 작업 내용
탈퇴하기 페이지 퍼블리싱을 진행했어요!
마지막 단계는 모달창 구조가 확정되지 않아 제외했으며, 공통 모달 컴포넌트가 완성된 뒤 탈퇴하기 모달까지 추가할 예정입니다.
탈퇴하기 버튼 스타일링은 추후 수정 예정이에요! < 이 부분 어떻게 할지 함께 논의했으면 합니다!!

- 탈퇴하기 라우팅 주소: `/delete-account`
- 탈퇴하기 버튼 클릭 시 `/delete-account/reason` 으로 이동

## 📸 스크린샷 / GIF / Link
<table>
  <tr>
    <td>
      <img width="632" height="880" alt="image" src="https://github.com/user-attachments/assets/61eaac01-7b90-45c2-a885-15fa1fa37860" />
    </td>
    <td>
      <img width="577" height="857" alt="image" src="https://github.com/user-attachments/assets/46858b3f-aad3-42c9-85bd-82fe81a06af3" />
    </td>
    <td>
      <img width="577" height="867" alt="image" src="https://github.com/user-attachments/assets/91a4cb05-d516-41da-8584-8a4d9de45d24" />
    </td>
  </tr>
</table>


## ✍ 궁금한 것
DeleteAccountReasonForm 과 ReportReasonForm 컴포넌트가 굉장히 유사한데 이를 통합할 방법은 없을까요!?
통합하게 되면 더 가독성이 떨어지려나요..!? 문구를 제외한 모든 디자인 구조, 컴포넌트 배치가 동일합니다.
조언이 필요해요🎃