### PR TITLE
feat: Button 컴포넌트 수정

### DIFF
--- a/src/app/delete-account/delete-account.css.ts
+++ b/src/app/delete-account/delete-account.css.ts
@@ -84,3 +84,11 @@ export const fixedButtonWrapper = style({
 
   padding: "0 2rem",
 });
+
+export const deleteButton = style({
+  flex: 1,
+});
+
+export const continueButton = style({
+  flex: 2,
+});

--- a/src/app/delete-account/page.tsx
+++ b/src/app/delete-account/page.tsx
@@ -51,8 +51,10 @@ export default function page() {
       </article>
 
       <div className={styles.fixedButtonWrapper}>
-        <Button onClick={handleClickDeleteAccount}>탈퇴하기</Button>
-        <Button>계속 이용하기</Button>
+        <Button className={styles.deleteButton} outlined>
+          탈퇴하기
+        </Button>
+        <Button className={styles.continueButton}>계속 이용하기</Button>
       </div>
     </>
   );

--- a/src/app/delete-account/page.tsx
+++ b/src/app/delete-account/page.tsx
@@ -51,7 +51,7 @@ export default function page() {
       </article>
 
       <div className={styles.fixedButtonWrapper}>
-        <Button className={styles.deleteButton} outlined>
+        <Button className={styles.deleteButton} outlined onClick={handleClickDeleteAccount}>
           탈퇴하기
         </Button>
         <Button className={styles.continueButton}>계속 이용하기</Button>

--- a/src/components/Common/Button/Button.tsx
+++ b/src/components/Common/Button/Button.tsx
@@ -1,15 +1,16 @@
 import { type ButtonHTMLAttributes, ReactNode, memo } from "react";
 
 import clsx from "clsx";
-import { buttonStyle } from "./button.css";
+import { buttonStyle, outlinedStyle } from "./button.css";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: ReactNode;
+  outlined?: boolean;
 }
 
-function Button({ children, className, ...buttonElementProps }: ButtonProps) {
+function Button({ children, className, outlined, ...buttonElementProps }: ButtonProps) {
   return (
-    <button className={clsx(buttonStyle, className)} {...buttonElementProps}>
+    <button className={clsx(buttonStyle, outlined && outlinedStyle, className)} {...buttonElementProps}>
       {children}
     </button>
   );

--- a/src/components/Common/Button/button.css.ts
+++ b/src/components/Common/Button/button.css.ts
@@ -1,10 +1,10 @@
-import { style } from '@vanilla-extract/css';
+import { style } from "@vanilla-extract/css";
 import { vars } from "@/styles/theme.css";
 
 export const buttonStyle = style({
   ...vars.fontStyles.title3_sb_20,
 
-  width: "100%",
+  // width: "100%",
   height: "5.5rem",
 
   borderRadius: "1.2rem",
@@ -18,4 +18,10 @@ export const buttonStyle = style({
       color: vars.color.grey_6,
     },
   },
+});
+
+export const outlinedStyle = style({
+  background: vars.color.white,
+  border: `1px solid ${vars.color.grey_4}`,
+  color: vars.color.grey_6,
 });

--- a/src/components/Common/Button/button.css.ts
+++ b/src/components/Common/Button/button.css.ts
@@ -22,6 +22,6 @@ export const buttonStyle = style({
 
 export const outlinedStyle = style({
   background: vars.color.white,
-  border: `1px solid ${vars.color.grey_4}`,
+boxShadow: `inset 0 0 0 1px ${vars.color.grey_4}`,
   color: vars.color.grey_6,
 });

--- a/src/components/Common/Button/button.css.ts
+++ b/src/components/Common/Button/button.css.ts
@@ -4,7 +4,7 @@ import { vars } from "@/styles/theme.css";
 export const buttonStyle = style({
   ...vars.fontStyles.title3_sb_20,
 
-  // width: "100%",
+  width: "100%",
   height: "5.5rem",
 
   borderRadius: "1.2rem",
@@ -22,6 +22,6 @@ export const buttonStyle = style({
 
 export const outlinedStyle = style({
   background: vars.color.white,
-  border: `1px solid ${vars.color.grey_4}`,
+  boxShadow: `inset 0 0 0 1px ${vars.color.grey_4}`,
   color: vars.color.grey_6,
 });


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #121 

## ✅ 작업 내용
Button 컴포넌트에 `outlined` props 추가했습니다.  판매리스트의 모달창에도 동일한 디자인으로 적용하면 될 것 같습니다!
디자이너님께 버튼 텍스트 관련해서 문의 남겨둔 상태라 답변오면 공유드리겠습니당😉

<table>
  <tr>
    <td>
      <img width="597" height="177" alt="before" src="https://github.com/user-attachments/assets/e0db7988-e608-43b2-b48d-956d606fe735" />
    </td>
    <td>
      <img width="383" height="127" alt="after" src="https://github.com/user-attachments/assets/ebfae206-06ca-43f6-aed0-afb346b9dfd4" />
    </td>
  </tr>
</table>