### PR TITLE
feat: 이미지 업로드 컴포넌트 미리보기 구현(api 연결 예정)

### DIFF
--- a/src/assets/icons/ic_plus_mint.svg
+++ b/src/assets/icons/ic_plus_mint.svg
@@ -1,0 +1,20 @@
+<svg width="37" height="37" viewBox="0 0 37 37" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_5034_13979)">
+<circle cx="18.1279" cy="18.6279" r="16.6279" fill="#14C3BC"/>
+<circle cx="18.1279" cy="18.6279" r="15.9884" stroke="white" stroke-width="1.27907"/>
+</g>
+<path d="M11.5 18H25.5" stroke="white" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M18.5 11L18.5 25" stroke="white" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+<defs>
+<filter id="filter0_d_5034_13979" x="0.22093" y="0.72093" width="35.814" height="35.814" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="0.639535"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_5034_13979"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_5034_13979" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/src/assets/icons/ic_profile.svg
+++ b/src/assets/icons/ic_profile.svg
@@ -1,24 +1,5 @@
-<svg width="113" height="112" viewBox="0 0 113 112" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="1.5" y="1" width="110" height="110" rx="55" fill="#F2F2F2"/>
-<rect x="1.5" y="1" width="110" height="110" rx="55" stroke="#DEDEDE" stroke-width="1.27907"/>
-<g filter="url(#filter0_d_4387_4071)">
-<circle cx="94.1279" cy="91.6279" r="16.6279" fill="#14C3BC"/>
-<circle cx="94.1279" cy="91.6279" r="15.9884" stroke="white" stroke-width="1.27907"/>
-</g>
-<path d="M87.5 91H101.5" stroke="white" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M94.5 84L94.5 98" stroke="white" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
-<circle cx="10.8333" cy="10.8333" r="10.8333" transform="matrix(-1 0 0 1 66.292 33.125)" fill="#C8C8C8"/>
-<path d="M36.5 70.8644C36.5 68.5343 37.9648 66.4557 40.1592 65.672C50.0526 62.1386 60.8641 62.1386 70.7575 65.672C72.9519 66.4557 74.4167 68.5343 74.4167 70.8644V74.4272C74.4167 77.6432 71.5683 80.1136 68.3846 79.6588L65.7998 79.2895C58.9403 78.3096 51.9764 78.3096 45.1169 79.2895L42.532 79.6588C39.3484 80.1136 36.5 77.6432 36.5 74.4272V70.8644Z" fill="#C8C8C8"/>
-<defs>
-<filter id="filter0_d_4387_4071" x="76.2209" y="73.7209" width="35.814" height="35.814" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-<feFlood flood-opacity="0" result="BackgroundImageFix"/>
-<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-<feOffset/>
-<feGaussianBlur stdDeviation="0.639535"/>
-<feComposite in2="hardAlpha" operator="out"/>
-<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
-<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4387_4071"/>
-<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_4387_4071" result="shape"/>
-</filter>
-</defs>
+<svg width="111" height="110" viewBox="0 0 111 110" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" width="110" height="110" rx="55" fill="#F2F2F2"/>
+<circle cx="10.8333" cy="10.8333" r="10.8333" transform="matrix(-1 0 0 1 65.292 32.125)" fill="#C8C8C8"/>
+<path d="M35.5 69.8644C35.5 67.5343 36.9648 65.4557 39.1592 64.672C49.0526 61.1386 59.8641 61.1386 69.7575 64.672C71.9519 65.4557 73.4167 67.5343 73.4167 69.8644V73.4272C73.4167 76.6432 70.5683 79.1136 67.3846 78.6588L64.7998 78.2895C57.9403 77.3096 50.9764 77.3096 44.1169 78.2895L41.532 78.6588C38.3484 79.1136 35.5 76.6432 35.5 73.4272V69.8644Z" fill="#C8C8C8"/>
 </svg>

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -29,6 +29,7 @@ import IcLogoKakao from "./ic_logo_kakao.svg";
 import IcLogoNaver from "./ic_logo_naver.svg";
 import IcMoreVertical from "./ic_more_vertical.svg";
 import IcPlus from "./ic_plus.svg";
+import IcPlusMint from "./ic_plus_mint.svg";
 import IcProfile from "./ic_profile.svg";
 import IcPencil from "./ic_pencil.svg";
 import IcSearch from "./ic_search.svg";
@@ -80,6 +81,7 @@ export {
   IcLogoNaver,
   IcMoreVertical,
   IcPlus,
+  IcPlusMint,
   IcProfile,
   IcPencil,
   IcSearch,

--- a/src/components/SignUp/Info/ImageInputForm/ImageInputForm.css.ts
+++ b/src/components/SignUp/Info/ImageInputForm/ImageInputForm.css.ts
@@ -1,7 +1,7 @@
 import { vars } from "@/styles/theme.css";
 import { style } from "@vanilla-extract/css";
 
-export const ImageInputFormWrapper = style({
+export const imageInputFormWrapper = style({
   display: "flex",
   flexDirection: "column",
   alignItems: "center",
@@ -15,7 +15,7 @@ export const previewWrapper = style({
   cursor: "pointer",
 });
 
-export const plus = style({
+export const profileImageLabel = style({
   display: "block",
   width: "100%",
   height: "100%",
@@ -23,6 +23,10 @@ export const plus = style({
   borderRadius: "50%",
   overflow: "hidden",
   boxShadow: `inset 0 0 0 1.28px ${vars.color.grey_5}`,
+});
+
+export const profileImageInput = style({
+  display: "none",
 });
 
 export const previewImage = style({

--- a/src/components/SignUp/Info/ImageInputForm/ImageInputForm.css.ts
+++ b/src/components/SignUp/Info/ImageInputForm/ImageInputForm.css.ts
@@ -1,8 +1,37 @@
+import { vars } from "@/styles/theme.css";
 import { style } from "@vanilla-extract/css";
 
 export const ImageInputFormWrapper = style({
   display: "flex",
   flexDirection: "column",
+  alignItems: "center",
+});
 
+export const previewWrapper = style({
+  width: "11rem",
+  height: "11rem",
+  borderRadius: "50%",
+  boxShadow: `inset 0 0 0 1.28px ${vars.color.grey_5}`,
+
+  position: "relative",
+  cursor: "pointer",
+});
+
+export const previewImage = style({
   width: "100%",
+  height: "100%",
+  borderRadius: "50%",
+
+  objectFit: "cover",
+});
+
+export const profileIcon = style({
+  width: "100%",
+  height: "100%",
+});
+
+export const addButton = style({
+  position: "absolute",
+  bottom: "0",
+  right: "0",
 });

--- a/src/components/SignUp/Info/ImageInputForm/ImageInputForm.css.ts
+++ b/src/components/SignUp/Info/ImageInputForm/ImageInputForm.css.ts
@@ -10,11 +10,19 @@ export const ImageInputFormWrapper = style({
 export const previewWrapper = style({
   width: "11rem",
   height: "11rem",
-  borderRadius: "50%",
-  boxShadow: `inset 0 0 0 1.28px ${vars.color.grey_5}`,
 
   position: "relative",
   cursor: "pointer",
+});
+
+export const plus = style({
+  display: "block",
+  width: "100%",
+  height: "100%",
+
+  borderRadius: "50%",
+  overflow: "hidden",
+  boxShadow: `inset 0 0 0 1.28px ${vars.color.grey_5}`,
 });
 
 export const previewImage = style({

--- a/src/components/SignUp/Info/ImageInputForm/ImageInputForm.tsx
+++ b/src/components/SignUp/Info/ImageInputForm/ImageInputForm.tsx
@@ -29,15 +29,15 @@ function ImageInputForm() {
   }, [previewUrl]);
 
   return (
-    <div className={styles.ImageInputFormWrapper}>
+    <div className={styles.imageInputFormWrapper}>
       <div className={styles.previewWrapper}>
-        <label htmlFor="profile-image-input" className={styles.plus}>
+        <label htmlFor="profile-image-input" className={styles.profileImageLabel}>
           <input
             id="profile-image-input"
             type="file"
             accept="image/*"
             onChange={handleChangeImage}
-            style={{ display: "none" }}
+            className={styles.profileImageInput}
           />
 
           {previewUrl ? (

--- a/src/components/SignUp/Info/ImageInputForm/ImageInputForm.tsx
+++ b/src/components/SignUp/Info/ImageInputForm/ImageInputForm.tsx
@@ -39,15 +39,7 @@ function ImageInputForm() {
           <IcProfile className={styles.profileIcon} />
         )}
 
-        <IconButton
-          icon={<IcPlusMint />}
-          label="프로필 사진 등록"
-          onClick={(e) => {
-            e.stopPropagation();
-            handleClickImage();
-          }}
-          className={styles.addButton}
-        />
+        <IconButton icon={<IcPlusMint />} label="프로필 사진 등록" className={styles.addButton} />
       </div>
     </div>
   );

--- a/src/components/SignUp/Info/ImageInputForm/ImageInputForm.tsx
+++ b/src/components/SignUp/Info/ImageInputForm/ImageInputForm.tsx
@@ -1,13 +1,54 @@
 "use client";
 
-import { IcProfile } from "@/assets/icons";
+import { IcPlusMint, IcProfile } from "@/assets/icons";
+import Image from "next/image";
 import { IconButton } from "@/components/Common/IconButton";
 import * as styles from "./ImageInputForm.css";
+import { useState, ChangeEvent } from "react";
 
 function ImageInputForm() {
+  const [image, setImage] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  const handleClickImageUpload = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setImage(file);
+    setPreviewUrl(URL.createObjectURL(file));
+  };
+
+  const handleClickImage = () => {
+    document.getElementById("profile-image-input")?.click();
+  };
+
   return (
     <div className={styles.ImageInputFormWrapper}>
-      <IconButton icon={<IcProfile />} label="프로필 사진 변경" />
+      <input
+        id="profile-image-input"
+        type="file"
+        accept="image/*"
+        onChange={handleClickImageUpload}
+        style={{ display: "none" }}
+      />
+
+      <div className={styles.previewWrapper} onClick={handleClickImage}>
+        {previewUrl ? (
+          <Image src={previewUrl} alt="미리보기" width={11} height={11} className={styles.previewImage} />
+        ) : (
+          <IcProfile className={styles.profileIcon} />
+        )}
+
+        <IconButton
+          icon={<IcPlusMint />}
+          label="프로필 사진 등록"
+          onClick={(e) => {
+            e.stopPropagation();
+            handleClickImage();
+          }}
+          className={styles.addButton}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/SignUp/Info/ImageInputForm/ImageInputForm.tsx
+++ b/src/components/SignUp/Info/ImageInputForm/ImageInputForm.tsx
@@ -2,44 +2,54 @@
 
 import { IcPlusMint, IcProfile } from "@/assets/icons";
 import Image from "next/image";
-import { IconButton } from "@/components/Common/IconButton";
 import * as styles from "./ImageInputForm.css";
-import { useState, ChangeEvent } from "react";
+import { useState, ChangeEvent, useEffect } from "react";
 
 function ImageInputForm() {
-  const [image, setImage] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
 
-  const handleClickImageUpload = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleChangeImage = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
 
-    setImage(file);
+    // 메모리 릭 방지
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl);
+    }
+
     setPreviewUrl(URL.createObjectURL(file));
   };
 
-  const handleClickImage = () => {
-    document.getElementById("profile-image-input")?.click();
-  };
+  useEffect(() => {
+    return () => {
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+      }
+    };
+  }, [previewUrl]);
 
   return (
     <div className={styles.ImageInputFormWrapper}>
-      <input
-        id="profile-image-input"
-        type="file"
-        accept="image/*"
-        onChange={handleClickImageUpload}
-        style={{ display: "none" }}
-      />
+      <div className={styles.previewWrapper}>
+        <label htmlFor="profile-image-input" className={styles.plus}>
+          <input
+            id="profile-image-input"
+            type="file"
+            accept="image/*"
+            onChange={handleChangeImage}
+            style={{ display: "none" }}
+          />
 
-      <div className={styles.previewWrapper} onClick={handleClickImage}>
-        {previewUrl ? (
-          <Image src={previewUrl} alt="미리보기" width={11} height={11} className={styles.previewImage} />
-        ) : (
-          <IcProfile className={styles.profileIcon} />
-        )}
+          {previewUrl ? (
+            <Image src={previewUrl} alt="프로필 미리보기" fill className={styles.previewImage} />
+          ) : (
+            <IcProfile className={styles.profileIcon} />
+          )}
+        </label>
 
-        <IconButton icon={<IcPlusMint />} label="프로필 사진 등록" className={styles.addButton} />
+        <div className={styles.addButton}>
+          <IcPlusMint />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #84 

## ✅ 작업 내용
이미지 업로드 컴포넌트(`ImageInputForm`)를 구현했습니다. 아직 api 연결은 안된 상태라 새로고침하면 이미지 미리보기가 날라가요!
api 연결 이전에 pr 날리면 좋겠다는 의견에 따라 해당 부분 먼저 pr 날립니다.

## 📸 스크린샷 / GIF / Link
https://github.com/user-attachments/assets/1a2a66e2-5db3-4b68-b05d-5f5b024d0367

## 📌 이슈 사항
이미지를 선택했는데 다시 선택하도록 또 업로드창이 떠서 확인해보니 IconButton과 previewWrapper 둘 다 클릭 이벤트가 `handleClickImage`를 호출하기 때문에 생기는 현상일 가능성이 높다고 해서, IconButton의 클릭 이벤트에 `e.stopPropagation()`을 호출해서 이벤트 버블링을 막았어요!!
> 찾아보니 무조건 이벤트버블링을 막는 건 좋지 않은 방법인 것 같아서, 코드 다시 확인해보니 previewWrapper 클릭으로 처리돼서 아예 IconButton의 클릭 이벤트를 삭제해도 정상 작동하네요...!!!
```
<IconButton
          icon={<IcPlusMint />}
          label="프로필 사진 등록"
          onClick={(e) => { // 클릭이벤트 제거 완료
            e.stopPropagation();
            handleClickImage();
          }}
          className={styles.addButton}
/>
```
## ✍ 궁금한 것
이미지 업로드 테두리를 넣으려고 하는데 잘 안됩니다🙃
`border: 1.28px solid ${vars.color.grey_5}` 로 주자니 미세하게 1.28px씩 밀리는 현상이 있어서 previewWrapper 스타일링에 `boxShadow: inset 0 0 0 1.28px ${vars.color.grey_5}`로 보더를 주었는데, 제대로 안 먹는 이슈가 있습니다.
profileIcon의 너비와 높이를 100%로 줘서 그런건지 어떤 이유때문인지 잘 모르겠어요.