### PR TITLE
feat: lint commit hook 세팅 & Lefthook 마이그레이션

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,0 @@
-yarn commitlint --edit $1

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,7 +5,7 @@ pre-commit:
   parallel: true
   commands:
     lint:
-      glob: "*.{js,jsx,ts,tsx,mjs}"
+      glob: "*.{js,jsx,ts,tsx}"
       run: echo "🔍 Running lint check before commit..." && yarn eslint {staged_files} && echo "✅ Lint check passed!"
 
 commit-msg:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,7 +6,7 @@ pre-commit:
   commands:
     lint:
       glob: "*.{js,jsx,ts,tsx,mjs}"
-      run: echo "🔍 Running lint check before commit..." && yarn lint {staged_files} && echo "✅ Lint check passed!"
+      run: echo "🔍 Running lint check before commit..." && yarn eslint {staged_files} && echo "✅ Lint check passed!"
 
 commit-msg:
   commands:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,14 @@
+# Lefthook configuration
+# https://github.com/evilmartians/lefthook
+
+pre-commit:
+  parallel: true
+  commands:
+    lint:
+      glob: "*.{js,jsx,ts,tsx,mjs}"
+      run: echo "🔍 Running lint check before commit..." && yarn lint {staged_files} && echo "✅ Lint check passed!"
+
+commit-msg:
+  commands:
+    commitlint:
+      run: yarn commitlint --edit {1}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "prepare": "husky"
+    "prepare": "lefthook install"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.66.0",
@@ -35,6 +35,7 @@
     "eslint-config-next": "15.1.7",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "lefthook": "^1.13.6",
     "prettier": "^3.5.1",
     "typescript": "^5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4977,6 +4977,117 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lefthook-darwin-arm64@npm:1.13.6":
+  version: 1.13.6
+  resolution: "lefthook-darwin-arm64@npm:1.13.6"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-darwin-x64@npm:1.13.6":
+  version: 1.13.6
+  resolution: "lefthook-darwin-x64@npm:1.13.6"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-freebsd-arm64@npm:1.13.6":
+  version: 1.13.6
+  resolution: "lefthook-freebsd-arm64@npm:1.13.6"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-freebsd-x64@npm:1.13.6":
+  version: 1.13.6
+  resolution: "lefthook-freebsd-x64@npm:1.13.6"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-linux-arm64@npm:1.13.6":
+  version: 1.13.6
+  resolution: "lefthook-linux-arm64@npm:1.13.6"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-linux-x64@npm:1.13.6":
+  version: 1.13.6
+  resolution: "lefthook-linux-x64@npm:1.13.6"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-openbsd-arm64@npm:1.13.6":
+  version: 1.13.6
+  resolution: "lefthook-openbsd-arm64@npm:1.13.6"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-openbsd-x64@npm:1.13.6":
+  version: 1.13.6
+  resolution: "lefthook-openbsd-x64@npm:1.13.6"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-windows-arm64@npm:1.13.6":
+  version: 1.13.6
+  resolution: "lefthook-windows-arm64@npm:1.13.6"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-windows-x64@npm:1.13.6":
+  version: 1.13.6
+  resolution: "lefthook-windows-x64@npm:1.13.6"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook@npm:^1.13.6":
+  version: 1.13.6
+  resolution: "lefthook@npm:1.13.6"
+  dependencies:
+    lefthook-darwin-arm64: "npm:1.13.6"
+    lefthook-darwin-x64: "npm:1.13.6"
+    lefthook-freebsd-arm64: "npm:1.13.6"
+    lefthook-freebsd-x64: "npm:1.13.6"
+    lefthook-linux-arm64: "npm:1.13.6"
+    lefthook-linux-x64: "npm:1.13.6"
+    lefthook-openbsd-arm64: "npm:1.13.6"
+    lefthook-openbsd-x64: "npm:1.13.6"
+    lefthook-windows-arm64: "npm:1.13.6"
+    lefthook-windows-x64: "npm:1.13.6"
+  dependenciesMeta:
+    lefthook-darwin-arm64:
+      optional: true
+    lefthook-darwin-x64:
+      optional: true
+    lefthook-freebsd-arm64:
+      optional: true
+    lefthook-freebsd-x64:
+      optional: true
+    lefthook-linux-arm64:
+      optional: true
+    lefthook-linux-x64:
+      optional: true
+    lefthook-openbsd-arm64:
+      optional: true
+    lefthook-openbsd-x64:
+      optional: true
+    lefthook-windows-arm64:
+      optional: true
+    lefthook-windows-x64:
+      optional: true
+  bin:
+    lefthook: bin/index.js
+  checksum: 10c0/c1919d60708be7e12e705f3a583755b959931ef09c9d8e2e453fb96889a9aa74f803196ceb375b3ce775abe5f4948ec86859b736357d6dc0be312f455a82f0aa
+  languageName: node
+  linkType: hard
+
 "levn@npm:^0.4.1":
   version: 0.4.1
   resolution: "levn@npm:0.4.1"
@@ -6400,6 +6511,7 @@ __metadata:
     eslint-plugin-react: "npm:^7.37.5"
     eslint-plugin-react-hooks: "npm:^5.2.0"
     framer-motion: "npm:^12.4.7"
+    lefthook: "npm:^1.13.6"
     lottie-react: "npm:^2.4.1"
     next: "npm:15.1.7"
     prettier: "npm:^3.5.1"


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #124 

## ✅ 작업 내용
lint를 검사하는 pre-commit hook을 추가했어요.
커밋 전에 lint 검사를 해서 실패하면 커밋이 되지 않습니다. pre-push hook으로 하지 않은 이유는 실패하면 린트 오류 해결을 위한 커밋이 또 추가되어야 하기 때문이에요. 린트 오류 없는 커밋만 깔끔하게 허용하자는 취지입니다.

husky 기반의 커밋 훅을 Lefthook으로 마이그레이션했어요. Lefthook이 Go 언어 기반이기 때문에 JS보다 훨씬 빠르고, 병렬 실행도 지원해서 속도 측면에서 이득 볼 부분이 많다고 판단했습니다. glob 패턴을 활용해서 lint-staged의 역할도 대체할 수 있습니다.

run 커맨드에 `yarn lint`가 아닌 `yarn eslint`로 되어있는 이유는 `next lint`가 인자로 특정 파일을 받지 않기 때문이에요. lint-staged 역할을 Lefthook으로 대신하기 위해 `yarn eslint {staged_files}` 형태로 검사합니다.

