### PR TITLE
feat: API Client 개발

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@vanilla-extract/recipes": "^0.5.5",
     "clsx": "^2.1.1",
     "framer-motion": "^12.4.7",
+    "ky": "^1.14.0",
     "lottie-react": "^2.4.1",
     "next": "15.1.7",
     "react": "^19.0.0",

--- a/src/common/apis/client/index.ts
+++ b/src/common/apis/client/index.ts
@@ -1,0 +1,53 @@
+import ky, { type Options } from "ky";
+
+import { accessTokenStore } from "../stores/token-store";
+import { reissueToken } from "../utils/reissue";
+
+interface ApiResponse<T> {
+  code: string;
+  message: string | null;
+  status: number;
+  data: T;
+}
+
+const baseApiClient = ky.create({
+  prefixUrl: process.env.NEXT_PUBLIC_API_BASE_URL,
+  timeout: 30000,
+  hooks: {
+    beforeRequest: [
+      (request) => {
+        const atk = accessTokenStore.get();
+        if (atk != null) {
+          request.headers.set("Authorization", `Bearer ${atk}`);
+        }
+      },
+    ],
+    afterResponse: [
+      async (request, _options, response) => {
+        if (response.status === 401) {
+          try {
+            const newToken = await reissueToken();
+            accessTokenStore.set(newToken);
+            return baseApiClient(request);
+          } catch (error) {
+            accessTokenStore.clear();
+            if (typeof window !== "undefined") {
+              window.location.href = "/login";
+            }
+            throw error;
+          }
+        }
+
+        return response;
+      },
+    ],
+  },
+});
+
+export const apiClient = {
+  get: <T>(url: string, options?: Options) => baseApiClient.get(url, options).json<ApiResponse<T>>(),
+  post: <T>(url: string, options?: Options) => baseApiClient.post(url, options).json<ApiResponse<T>>(),
+  put: <T>(url: string, options?: Options) => baseApiClient.put(url, options).json<ApiResponse<T>>(),
+  patch: <T>(url: string, options?: Options) => baseApiClient.patch(url, options).json<ApiResponse<T>>(),
+  delete: <T>(url: string, options?: Options) => baseApiClient.delete(url, options).json<ApiResponse<T>>(),
+};

--- a/src/common/apis/constants/http.ts
+++ b/src/common/apis/constants/http.ts
@@ -1,0 +1,21 @@
+export const HTTP_STATUS_CODE = {
+  NETWORK_ERROR: 0,
+  OK: 200,
+  CREATED: 201,
+  NO_CONTENT: 204,
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  CONFLICT: 409,
+  INTERNAL_SERVER_ERROR: 500,
+} as const;
+
+export const HTTP_ERROR_MESSAGE = {
+  [HTTP_STATUS_CODE.BAD_REQUEST]: "잘못된 요청입니다.",
+  [HTTP_STATUS_CODE.UNAUTHORIZED]: "인증이 필요합니다.",
+  [HTTP_STATUS_CODE.FORBIDDEN]: "접근 권한이 없습니다.",
+  [HTTP_STATUS_CODE.NOT_FOUND]: "리소스를 찾을 수 없습니다.",
+  [HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR]: "서버 오류가 발생했습니다.",
+  [HTTP_STATUS_CODE.NETWORK_ERROR]: "네트워크 연결을 확인해주세요.",
+} as const;

--- a/src/common/apis/stores/token-store.ts
+++ b/src/common/apis/stores/token-store.ts
@@ -3,16 +3,16 @@ const SESSION_STORAGE_KEY = "ACCESS_TOKEN";
 export const accessTokenStore = {
   get: () => {
     if (typeof window === "undefined") return null;
-    return localStorage.getItem(SESSION_STORAGE_KEY);
+    return sessionStorage.getItem(SESSION_STORAGE_KEY);
   },
   set: (atk: string) => {
     if (typeof window !== "undefined") {
-      localStorage.setItem(SESSION_STORAGE_KEY, atk);
+      sessionStorage.setItem(SESSION_STORAGE_KEY, atk);
     }
   },
   clear: () => {
     if (typeof window !== "undefined") {
-      localStorage.removeItem(SESSION_STORAGE_KEY);
+      sessionStorage.removeItem(SESSION_STORAGE_KEY);
     }
   },
 };

--- a/src/common/apis/stores/token-store.ts
+++ b/src/common/apis/stores/token-store.ts
@@ -1,0 +1,18 @@
+const SESSION_STORAGE_KEY = "ACCESS_TOKEN";
+
+export const accessTokenStore = {
+  get: () => {
+    if (typeof window === "undefined") return null;
+    return localStorage.getItem(SESSION_STORAGE_KEY);
+  },
+  set: (atk: string) => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem(SESSION_STORAGE_KEY, atk);
+    }
+  },
+  clear: () => {
+    if (typeof window !== "undefined") {
+      localStorage.removeItem(SESSION_STORAGE_KEY);
+    }
+  },
+};

--- a/src/common/apis/utils/reissue.ts
+++ b/src/common/apis/utils/reissue.ts
@@ -1,0 +1,21 @@
+import ky from "ky";
+
+// ResponseType 몰라서 추가 못 한 상태
+// export interface ReissueResponse {}
+
+export async function reissueToken() {
+  // apiClient 미사용 - afterResponse hook에서 무한 루프 발생 방지
+  const response = await ky.post(`${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/refresh`, {
+    credentials: "include",
+  });
+
+  const authHeader = response.headers.get("Authorization") || response.headers.get("authorization");
+
+  if (!authHeader) {
+    throw new Error("accessToken 추출에 실패했습니다.");
+  }
+
+  const token = authHeader.replace(/^Bearer\s+/i, "");
+
+  return token;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4961,6 +4961,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ky@npm:^1.14.0":
+  version: 1.14.0
+  resolution: "ky@npm:1.14.0"
+  checksum: 10c0/ae30950feaa863fd95854bc0f528a04a36fa04828c119b098c5a0933a46126ccaee829ec0d6d6fc968faa4d0a23501c3203534d024d60540541d322d9772983d
+  languageName: node
+  linkType: hard
+
 "language-subtag-registry@npm:^0.3.20":
   version: 0.3.23
   resolution: "language-subtag-registry@npm:0.3.23"
@@ -6511,6 +6518,7 @@ __metadata:
     eslint-plugin-react: "npm:^7.37.5"
     eslint-plugin-react-hooks: "npm:^5.2.0"
     framer-motion: "npm:^12.4.7"
+    ky: "npm:^1.14.0"
     lefthook: "npm:^1.13.6"
     lottie-react: "npm:^2.4.1"
     next: "npm:15.1.7"


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #129 

## ✅ 작업 내용

API Client 모듈을 개발했어요.
인증이 필요한 클라이언트 패칭시에만 사용하면 됩니다.

저희는 R.T 탈취위험을 낮추기 위해 A.T가 cookie로 관리되지 않도록 설계했기 때문에 서버 환경에서 A.T에 접근할 방법이 없어 개인화된 요청은 서버 패칭으로 처리하기가 어려워요. 또 개인화된 요청은 서버캐싱을 활용할 수도 없습니다. 또 개인화된 요청이 있는 페이지는 로그인 후 접근 가능한 페이지이기 때문에 SEO에도 영향을 미치지 못해 서버 패칭으로 얻을 수 있는 이득이 적다고 판단했어요. 그래서 개인화된 요청은 클라이언트 패칭을 사용하고, 인증 관련 오류 발생 시 reissue 후 재요청하는 로직을 추가했어요.

일부 API를 제외한 대부분의 API가 개인화된 요청이기 때문에 서버 fetch Wrapper나, 개인화되지 않은 클라이언트 public API Client를 만드는 것은 오버엔지니어링이라는 판단이 들어 따로 개발하지는 않았어요. 추후 관련 API가 많아진다거나 유지보수가 어려울 것 같다고 판단이 들면 추가할 예정입니다~!

지금 로그아웃 기능이 별도로 없어서 세션 종료 시 자동 로그아웃되도록 세션스토리지에서 토큰을 관리하도록 해두었어요.

++ 서버 health 체크했는데 아직 이관 작업 중인것 같아서 이관 끝나면 테스트 해보고 문제 있는 부분 수정할게요 😃