### PR TITLE
feat: Divider 공통 컴포넌트 구현

### DIFF
--- a/src/app/mypage/mypage.css.ts
+++ b/src/app/mypage/mypage.css.ts
@@ -71,7 +71,7 @@ export const myInfoContainer = style({
   backgroundColor: vars.color.grey_2,
 
   borderRadius: "1rem",
-  margin: "2rem",
+  margin: "1.6rem 2rem 2.3rem 2rem",
 });
 
 export const myInfoWrapper = style({
@@ -106,15 +106,8 @@ export const verticalLine = style({
   alignSelf: "center",
 });
 
-export const divider = style({
-  height: "0.8rem",
-
-  backgroundColor: vars.color.grey_2,
-  margin: "2.3rem 0",
-});
-
 export const myActivityWrapper = style({
-  padding: "0 2rem",
+  padding: "2.3rem 2rem",
 });
 
 export const myActivityText = style({

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -42,7 +42,7 @@ export default function MyPage() {
           </div>
         </section>
 
-        <Divider height="0.8rem" />
+        <Divider height={0.8} />
 
         <div className={styles.myActivityWrapper}>
           <span className={styles.myActivityText}>나의 활동</span>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -5,6 +5,7 @@ import { IconButton } from "@/components/Common/IconButton";
 import { NavBar } from "@/components/Common/NavBar/NavBar";
 import Image from "next/image";
 import * as styles from "./mypage.css";
+import { Divider } from "@/components/Common/Divider/Divider";
 
 export default function MyPage() {
   return (
@@ -41,7 +42,7 @@ export default function MyPage() {
           </div>
         </section>
 
-        <div className={styles.divider}></div>
+        <Divider height="0.8rem" />
 
         <div className={styles.myActivityWrapper}>
           <span className={styles.myActivityText}>나의 활동</span>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -3,6 +3,7 @@ import { BackButton } from "@/components/Common/BackButton/BackButton";
 import { Header } from "@/components/Common/Header/Header";
 import Link from "next/link";
 import * as styles from "./settings.css";
+import { Divider } from "@/components/Common/Divider/Divider";
 
 export default function SettingsPage() {
   // TODO: Link 컴포넌트의 href 경로 정해지면 수정하기
@@ -36,7 +37,7 @@ export default function SettingsPage() {
         ))}
       </section>
 
-      <hr className={styles.divider} />
+      <Divider />
 
       <section className={styles.settingSection}>
         <h3 className={styles.settingText}>기타</h3>
@@ -48,7 +49,7 @@ export default function SettingsPage() {
         ))}
       </section>
 
-      <hr className={styles.divider} />
+      <Divider />
 
       <section className={styles.settingSection}>
         <button className={styles.infoRow}>

--- a/src/app/settings/settings.css.ts
+++ b/src/app/settings/settings.css.ts
@@ -31,14 +31,6 @@ export const infoText = style({
   color: vars.color.grey_11,
 });
 
-export const divider = style({
-  width: "100%",
-  height: "1rem",
-
-  backgroundColor: vars.color.grey_2,
-  border: "none",
-});
-
 export const versionText = style({
   ...vars.fontStyles.body3_r_14,
   color: vars.color.grey_7,

--- a/src/app/user/[nickname]/page.tsx
+++ b/src/app/user/[nickname]/page.tsx
@@ -5,6 +5,7 @@ import * as styles from "./user.css";
 import { NavBar } from "@/components/Common/NavBar/NavBar";
 import Image from "next/image";
 import { IcBubble, IcForSale, IcSoldout, IcVerticalLine } from "@/assets/icons";
+import { Divider } from "@/components/Common/Divider/Divider";
 
 export default function UserPage() {
   return (
@@ -44,7 +45,7 @@ export default function UserPage() {
           </div>
         </section>
 
-        <div className={styles.divider}></div>
+        <Divider height="0.8rem" />
 
         <div className={styles.activityWrapper}>
           <span className={styles.activityText}>활동</span>

--- a/src/app/user/[nickname]/page.tsx
+++ b/src/app/user/[nickname]/page.tsx
@@ -45,7 +45,7 @@ export default function UserPage() {
           </div>
         </section>
 
-        <Divider height="0.8rem" />
+        <Divider height={0.8} />
 
         <div className={styles.activityWrapper}>
           <span className={styles.activityText}>활동</span>

--- a/src/app/user/[nickname]/user.css.ts
+++ b/src/app/user/[nickname]/user.css.ts
@@ -85,7 +85,7 @@ export const myInfoContainer = style({
   backgroundColor: vars.color.grey_2,
 
   borderRadius: "1rem",
-  margin: "2rem 2rem 0 2rem",
+  margin: "1.6rem 2rem 2.3rem 2rem",
 });
 
 export const myInfoWrapper = style({
@@ -123,15 +123,8 @@ export const verticalLine = style({
   alignSelf: "center",
 });
 
-export const divider = style({
-  height: "0.8rem",
-
-  backgroundColor: vars.color.grey_2,
-  margin: "2.3rem 0",
-});
-
 export const activityWrapper = style({
-  padding: "0 2rem",
+  padding: "2.3rem 2rem",
 });
 
 export const activityText = style({

--- a/src/components/Common/Divider/Divider.tsx
+++ b/src/components/Common/Divider/Divider.tsx
@@ -1,9 +1,9 @@
 import * as styles from "./divider.css";
 
 interface DividerProps {
-  height?: string;
+  height?: number;
 }
 
-export function Divider({ height = "1rem" }: DividerProps) {
-  return <hr className={styles.divider} style={{ "--divider-height": height } as React.CSSProperties} />;
+export function Divider({ height = 1 }: DividerProps) {
+  return <hr className={styles.divider} style={{ height: `${height}rem` }} />;
 }

--- a/src/components/Common/Divider/Divider.tsx
+++ b/src/components/Common/Divider/Divider.tsx
@@ -1,0 +1,9 @@
+import * as styles from "./divider.css";
+
+interface DividerProps {
+  height?: string;
+}
+
+export function Divider({ height = "1rem" }: DividerProps) {
+  return <hr className={styles.divider} style={{ "--divider-height": height } as React.CSSProperties} />;
+}

--- a/src/components/Common/Divider/divider.css.ts
+++ b/src/components/Common/Divider/divider.css.ts
@@ -1,0 +1,11 @@
+import { vars } from "@/styles/theme.css";
+import { style } from "@vanilla-extract/css";
+
+export const divider = style({
+  width: "100%",
+  height: "var(--divider-height)",
+
+  backgroundColor: vars.color.grey_2,
+  border: "none",
+  margin: "0",
+});

--- a/src/components/Common/Divider/divider.css.ts
+++ b/src/components/Common/Divider/divider.css.ts
@@ -3,7 +3,6 @@ import { style } from "@vanilla-extract/css";
 
 export const divider = style({
   width: "100%",
-  height: "var(--divider-height)",
 
   backgroundColor: vars.color.grey_2,
   border: "none",


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #138 

## ✅ 작업 내용
Divider 컴포넌트를 구현했어요.
설정페이지, 마이페이지, 유저페이지 총 3가지 화면에 사용되는 구분선입니다.
기본 높이는 1rem으로 설정하고, 필요한 경우 `<Divider height="0.8rem" />` 처럼 prop으로 높이를 조절할 수 있도록 구현했습니다!!

## 📸 스크린샷 / GIF / Link
| 설정페이지 | 마이페이지 | 유저페이지 |
| --- | --- | --- |
| <img src="https://github.com/user-attachments/assets/0809533a-a827-4745-8728-37d5c1a956bb" width="300" /> | <img src="https://github.com/user-attachments/assets/c5a9194c-3170-4639-901b-9127ec83234e" width="300" /> | <img src="https://github.com/user-attachments/assets/c2bc8150-940b-4fef-98ab-6b168dc7b6f6" width="300" /> |