### PR TITLE
feat: useModal hook 구현

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ModalProvider } from "@/common/providers/ModalProvider";
 import { isServer, MutationCache, QueryCache, QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 function makeQueryClient() {
@@ -24,7 +25,11 @@ function getQueryClient() {
 export default function Providers({ children }: { children: React.ReactNode }) {
   const queryClient = getQueryClient();
 
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ModalProvider>{children}</ModalProvider>
+    </QueryClientProvider>
+  );
 }
 
 // 중앙 집중 에러 핸들링 방식으로 구현

--- a/src/common/hooks/useModal.tsx
+++ b/src/common/hooks/useModal.tsx
@@ -19,7 +19,15 @@ export function useModal<P extends ModalComponentProps>(
 
   const close = useCallback(() => {
     setIsOpen(false);
-    setModals((prev) => prev.filter((m) => m.id !== id));
+    setModals((prev) => {
+      const next = prev.filter((m) => m.id !== id);
+  
+      if (next.length === 0) {
+        document.body.style.overflow = "unset";
+      }
+  
+      return next;
+    });
   }, [id, setModals]);
 
   const open = useCallback(
@@ -37,6 +45,7 @@ export function useModal<P extends ModalComponentProps>(
         }
         return [...prev, { id, element }];
       });
+      document.body.style.overflow = "hidden";
     },
     [id, setModals, close, Component]
   );

--- a/src/common/hooks/useModal.tsx
+++ b/src/common/hooks/useModal.tsx
@@ -1,0 +1,45 @@
+import React, { useCallback, useContext, useId, useState } from "react";
+import { ModalContext } from "../providers/ModalProvider";
+
+interface ModalComponentProps {
+  onClose: () => void;
+}
+
+export function useModal<P extends ModalComponentProps>(
+  Component: React.ComponentType<P>
+) {
+  const context = useContext(ModalContext);
+
+  if (!context) throw new Error("useModal은 ModalProvider 안에서 호출해야 합니다.");
+
+  const { setModals } = context;
+
+  const id = useId();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    setModals((prev) => prev.filter((m) => m.id !== id));
+  }, [id, setModals]);
+
+  const open = useCallback(
+    (props?: Omit<P, "onClose">) => {
+      setIsOpen(true);
+      setModals((prev) => {
+        const exists = prev.some((m) => m.id === id);
+        const element = React.createElement(Component, {
+          ...props,
+          onClose: close,
+        } as P);
+
+        if (exists) {
+          return prev.map((m) => (m.id === id ? { id, element } : m));
+        }
+        return [...prev, { id, element }];
+      });
+    },
+    [id, setModals, close, Component]
+  );
+
+  return { isOpen, open, close };
+}

--- a/src/common/hooks/useModal.tsx
+++ b/src/common/hooks/useModal.tsx
@@ -14,6 +14,13 @@ export function useModal<P extends ModalComponentProps>(
 
   const { setModals } = context;
 
+  const modalContainerStyle: React.CSSProperties = {
+    position: "fixed",
+    top: "50%",
+    left: "50%",
+    transform: "translate(-50%, -50%)",
+  };
+
   const id = useId();
   const [isOpen, setIsOpen] = useState(false);
 
@@ -35,10 +42,11 @@ export function useModal<P extends ModalComponentProps>(
       setIsOpen(true);
       setModals((prev) => {
         const exists = prev.some((m) => m.id === id);
-        const element = React.createElement(Component, {
-          ...props,
-          onClose: close,
-        } as P);
+        const element = (
+          <div style={modalContainerStyle}>
+            <Component {...(props as P)} onClose={close} />
+          </div>
+        );
 
         if (exists) {
           return prev.map((m) => (m.id === id ? { id, element } : m));

--- a/src/common/hooks/useModal.tsx
+++ b/src/common/hooks/useModal.tsx
@@ -42,16 +42,17 @@ export function useModal<P extends ModalComponentProps>(
       setIsOpen(true);
       setModals((prev) => {
         const exists = prev.some((m) => m.id === id);
-        const element = (
-          <div style={modalContainerStyle}>
-            <Component {...(props as P)} onClose={close} />
-          </div>
-        );
+        const render = (isTop: boolean) =>  (
+            <div style={{...modalContainerStyle, pointerEvents: isTop ? "auto" : "none"}}>
+              <Component {...(props as P)} onClose={close} />
+            </div>
+          );
+
 
         if (exists) {
-          return prev.map((m) => (m.id === id ? { id, element } : m));
+          return prev.map((m) => (m.id === id ? { id, render } : m));
         }
-        return [...prev, { id, element }];
+        return [...prev, { id, render }];
       });
       document.body.style.overflow = "hidden";
     },

--- a/src/common/providers/ModalProvider.tsx
+++ b/src/common/providers/ModalProvider.tsx
@@ -1,3 +1,4 @@
+import { Z_INDEX } from "@/constants/zIndex";
 import { createContext, Fragment, ReactNode, useState } from "react";
 
 type ModalItem = {
@@ -14,12 +15,26 @@ export const ModalContext = createContext<ModalContextType | null>(null);
 export function ModalProvider({ children }: { children: ReactNode }) {
   const [modals, setModals] = useState<ModalItem[]>([]);
 
+  const backdropStyle: React.CSSProperties = {
+    position: "fixed",
+    inset: 0,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    zIndex: Z_INDEX.BACKDROP,
+  };
+
   return (
     <ModalContext.Provider value={{ setModals }}>
       {children}
-      {modals.map(({ id, element }) => (
-        <Fragment key={id}>{element}</Fragment>
-      ))}
+      {modals.length > 0 && (
+        <div style={backdropStyle}>
+          {modals.map(({ id, element }) => (
+            <Fragment key={id} >
+              {element}
+            </Fragment>
+          ))}
+        </div>
+      )}
+      
     </ModalContext.Provider>
   );
 }

--- a/src/common/providers/ModalProvider.tsx
+++ b/src/common/providers/ModalProvider.tsx
@@ -18,7 +18,7 @@ export function ModalProvider({ children }: { children: ReactNode }) {
   const backdropStyle: React.CSSProperties = {
     position: "fixed",
     inset: 0,
-    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    backgroundColor: "rgba(90, 90, 90, 0.38)",
     zIndex: Z_INDEX.BACKDROP,
   };
 

--- a/src/common/providers/ModalProvider.tsx
+++ b/src/common/providers/ModalProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, Fragment, ReactNode, useEffect, useState } from "react";
+import { createContext, Fragment, ReactNode, useState } from "react";
 
 type ModalItem = {
   id: string;
@@ -6,7 +6,6 @@ type ModalItem = {
 };
 
 type ModalContextType = {
-  modals: ModalItem[];
   setModals: React.Dispatch<React.SetStateAction<ModalItem[]>>;
 };
 
@@ -15,21 +14,8 @@ export const ModalContext = createContext<ModalContextType | null>(null);
 export function ModalProvider({ children }: { children: ReactNode }) {
   const [modals, setModals] = useState<ModalItem[]>([]);
 
-  // 모달이 떠있으면 스크롤 막는 로직
-  useEffect(() => {
-    if (modals.length > 0) {
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = "";
-    }
-
-    return () => {
-      document.body.style.overflow = "";
-    };
-  }, [modals.length]);
-
   return (
-    <ModalContext.Provider value={{ modals, setModals }}>
+    <ModalContext.Provider value={{ setModals }}>
       {children}
       {modals.map(({ id, element }) => (
         <Fragment key={id}>{element}</Fragment>

--- a/src/common/providers/ModalProvider.tsx
+++ b/src/common/providers/ModalProvider.tsx
@@ -1,0 +1,39 @@
+import { createContext, Fragment, ReactNode, useEffect, useState } from "react";
+
+type ModalItem = {
+  id: string;
+  element: ReactNode;
+};
+
+type ModalContextType = {
+  modals: ModalItem[];
+  setModals: React.Dispatch<React.SetStateAction<ModalItem[]>>;
+};
+
+export const ModalContext = createContext<ModalContextType | null>(null);
+
+export function ModalProvider({ children }: { children: ReactNode }) {
+  const [modals, setModals] = useState<ModalItem[]>([]);
+
+  // 모달이 떠있으면 스크롤 막는 로직
+  useEffect(() => {
+    if (modals.length > 0) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [modals.length]);
+
+  return (
+    <ModalContext.Provider value={{ modals, setModals }}>
+      {children}
+      {modals.map(({ id, element }) => (
+        <Fragment key={id}>{element}</Fragment>
+      ))}
+    </ModalContext.Provider>
+  );
+}

--- a/src/common/providers/ModalProvider.tsx
+++ b/src/common/providers/ModalProvider.tsx
@@ -1,9 +1,9 @@
 import { Z_INDEX } from "@/constants/zIndex";
-import { createContext, Fragment, ReactNode, useState } from "react";
+import { createContext, ReactNode, useState } from "react";
 
 type ModalItem = {
   id: string;
-  element: ReactNode;
+  render: (isTop: boolean) => ReactNode;
 };
 
 type ModalContextType = {
@@ -27,11 +27,14 @@ export function ModalProvider({ children }: { children: ReactNode }) {
       {children}
       {modals.length > 0 && (
         <div style={backdropStyle}>
-          {modals.map(({ id, element }) => (
-            <Fragment key={id} >
-              {element}
-            </Fragment>
-          ))}
+          {modals.map(({ id, render }, idx) => {
+            const isTop = idx === modals.length - 1;
+            return (
+            <div key={id}>
+                {render(isTop)}
+              </div>
+            );
+          })}
         </div>
       )}
       

--- a/src/constants/zIndex.ts
+++ b/src/constants/zIndex.ts
@@ -1,5 +1,5 @@
 export const Z_INDEX = {
-    MODAL: 1000,
+    BACKDROP: 1000,
     DROPDOWN: 100,
     HEADER: 10,
 } as const;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #140

## ✅ 작업 내용

Modal을 편리하고 선언적으로 사용하기 위한 `useModal` hook을 구현했어요. 요 hook을 사용하면 Modal의 open 상태를 페이지 혹은 컴포넌트에서 직접 관리하지 않아도 되는 장점이 있습니다. 이제 Modal을 구현할 때 UI 그 자체의 구현에만 집중하면 돼요.

사용법은 다음과 같아요. `open()`, `close()`로 선언적으로 모달을 열고 닫을 수 있어요.

```tsx
const modal = useModal(Modal);

modal.open(); // 모달 열기
modal.close(); // 모달 닫기
```

추가적으로 Modal 내부에서 모달을 닫을 수 있도록 onClose prop으로 close 함수를 매핑해주기 때문에 Modal 내부에서 onClose prop을 받아서 사용하면 돼요.

```jsx
export default function Modal({ onClose }) {
  return (
    <div>
      <h1>Test Modal</h1>
      <button onClick={onClose}>닫기</button>
    </div>
  );
}
```

useModal의 인자로는 JSX가 아니라 컴포넌트 함수를 넘겨줘야 해요. 모달의 렌더링은 useModal hook이 호출되는 시점이 아니라 open이 호출되는 시점에 하게 됩니다.

```tsx
const modal = useModal(Modal);
const modal2 = useModal(({onClose}) => <Modal onClose={onClose} />);
const modal3 = useModal(({onClose}) => <div><button onClick={onClose}>닫기</button></div>)
```

Modal 컴포넌트에 prop을 전달하고 싶다면, `open()` 함수에 인자로 넣어주면 됩니다.

```jsx
modal.open({title: "제목", content: "컨텐츠"})
```

`useModal()`은 한 번의 호출 당 하나의 인스턴스를 관리합니다. 만약 동일한 컴포넌트인데 prop만 달라서 `useModal()`을 1번만 호출하고 props를 다르게 해서 open을 2번 했다! 라고 하면 기존 Modal 인스턴스를 버리고 새로운 인스턴스로 교체합니다.

```jsx
const modal = useModal(Modal);

modal.open({title: "제목", content: "컨텐츠"});
modal.open({title: "바보", content: "메롱"}); // 제목컨텐츠 모달이 사라지고 바보메롱 모달 등장
```

만약 두 개를 띄우는 게 의도였다면, useModal을 2번 호출해야 합니다.
그 이유는 close 함수가 항상 단일 인스턴스에 매핑되어서 꼬임 없이 안전하게 모달을 삭제하기 위함이에요. 스택 구조로 항상 맨 위에 있는 모달을 삭제하게 할 수도 있겠지만(그게 일반적인 동작이지만), 좀 더 확장성 있게 모달을 쓸 수 있을 거라고 생각했어요. (ex) 뒷 모달이 5초 뒤에 사라져야 하는데 3초 뒤에 새 모달이 열리면..?)

```jsx
const modal = useModal(Modal);
const modal2 = useModal(Modal);

modal.open({title: "제목", content: "컨텐츠"});
modal2.open({title: "바보", content: "메롱"}); // 제목컨텐츠 모달이 사라지지 않고 바보메롱 모달 등장
```



구현은 크게 `Provider`와 `Hook` 부분으로 관심사를 분리하여 구현했어요.

`Provider`는 modal들을 모아서 관리하고 순서대로 렌더링하는 역할을 해요.
모달은 한 번에 여러개가 뜰 수도 있기 때문에 이를 상정해서 배열로 구현했어요.

`Hook`은 개별 modal을 열거나, 닫거나 하는 Controller 역할을 해요. 매개변수로 받은 모달을 열고 닫는 기능을 합니다.

Modal은 stacking context로 인한 이슈가 있을 수 있는데, Page보다 상위 맥락인 Provider에서 렌더링을 하기 때문에 이로부터 자유로워요. 그래서 Portal을 따로 사용하지는 않았어요.

Backdrop은 모달이 하나 이상 open될때 자동으로 추가되고, 모달이 전부 닫히면 자동으로 사라져요. Backdrop의 자식으로 Modal이 들어오기 때문에 Backdrop의 z-index값만 신경쓰면 Modal이 Backdrop 위로 무조건 올라오는 구조입니다. 사실 현재 페이지 컴포넌트 서브트리랑은 완전히 분리되어있는 트리이기 때문에 z-index를 1로 해도 위로 잘 뜨는데요, 의미상 모달이 가장 위에 있다!! 라는 의미를 강조하고자 의도적으로 1000이라는 값을 주었어요. 혹여나 추후 동일한 레벨에 toast가 추가되어야 할 때는 둘의 우선순위에 따라 재조정할 필요가 있습니다.

단일 Backdrop이기 때문에 기본적으로 Modal이 쌓일 때 뒤에 있는 Modal과의 상호작용이 막히지는 않아요. 그래서 최상위 모달이 아닌 모달은 `pointerEvent`를 막음으로써 최상위 모달하고만 상호작용하고자 했어요.
기존엔 `useModal`에서 Component를 렌더한 결과(React Element)를 `modals` 프로퍼티로 저장했는데, `useModal`은 open() 호출 시점에 element가 만들어져요. 나중에 다른 모달이 열리면 이 element는 최상위가 아닌데, 그 정보가 자동으로 업데이트되지는 않으므로 "이제 최상위가 아니다"라는 정보를 모릅니다.

최상위 모달인지 아닌지는 `modals` 상태를 관리하는 provider에요. `modals` 상태가 바뀌면 Provider가 리렌더링되므로, 모달 컴포넌트들을 이 리렌더링에 같이 태우면 지금 최상위인지 아닌지를 계속 계산할 것이라고 생각했어요. 그래서 `useModal`은 JSX가 아닌 `render` 함수를 `modals` 프로퍼티로 저장합니다. 이렇게 해서 매 리렌더링마다 무엇이 최상위인지 검사해서 나머지 모달의 인터랙션을 막을 수 있었어요.

현재 backdrop을 눌렀을 때 자동으로 모달이 꺼지는 기능은 명세에 없었으므로 구현하지 않았어요. 만약 추가되어야 한다면 현재 Provider에서 close를 모르므로, 구조를 조금 변경해야 해요.

## 📸 스크린샷 / GIF / Link

첫 번째 모달을 열고, 그 내부에서 두 번째 모달을 여는 시연 영상입니다.
두 번째 모달이 열린 상태에서 첫 번째 모달의 닫기 버튼을 눌러도, 첫 번째 모달이 닫히지 않는 것을 확인할 수 있어요.


https://github.com/user-attachments/assets/5ec88d6f-c9b6-45ab-86a1-113e27fd9b44

