### PR TITLE
feat: ConfirmModal 구현 (Common)

### DIFF
--- a/src/components/Common/ConfirmModal/confirmModal.css.ts
+++ b/src/components/Common/ConfirmModal/confirmModal.css.ts
@@ -1,0 +1,31 @@
+import { vars } from "@/styles/theme.css";
+import { style } from "@vanilla-extract/css";
+
+export const modalWrapper = style({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: "2rem",
+
+  width: "28.7rem",
+  padding: "2.6rem 1.5rem",
+  backgroundColor: vars.color.white,
+  borderRadius: "1.2rem",
+});
+
+export const title = style({
+  ...vars.fontStyles.subtitle2_m_16,
+  color: vars.color.black,
+});
+
+export const buttonWrapper = style({
+  width: "100%",
+  display: "flex",
+  gap: "1rem",
+});
+
+export const button = style({
+  height: "4rem",
+  ...vars.fontStyles.body4_sb_13,
+});

--- a/src/components/Common/ConfirmModal/index.tsx
+++ b/src/components/Common/ConfirmModal/index.tsx
@@ -30,11 +30,11 @@ export function ConfirmModal({ onConfirm, onClose, title, confirmText, cancelTex
         {title}
       </h2>
       <div className={styles.buttonWrapper}>
-        <Button onClick={onConfirm} className={styles.button}>
-          {confirmText}
-        </Button>
         <Button onClick={onClose} className={styles.button} outlined>
           {cancelText}
+        </Button>
+        <Button onClick={onConfirm} className={styles.button}>
+          {confirmText}
         </Button>
       </div>
     </div>

--- a/src/components/Common/ConfirmModal/index.tsx
+++ b/src/components/Common/ConfirmModal/index.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "react";
+import Button from "../Button/Button";
+import * as styles from "./confirmModal.css";
+
+interface ConfirmModalProps {
+  onConfirm: () => void;
+  onClose: () => void;
+  title: string;
+  confirmText: string;
+  cancelText: string;
+}
+
+export function ConfirmModal({ onConfirm, onClose, title, confirmText, cancelText }: ConfirmModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    dialogRef.current?.focus();
+  }, []);
+
+  return (
+    <div
+      ref={dialogRef}
+      className={styles.modalWrapper}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-modal-title"
+      tabIndex={-1}
+    >
+      <h2 className={styles.title} id="confirm-modal-title">
+        {title}
+      </h2>
+      <div className={styles.buttonWrapper}>
+        <Button onClick={onConfirm} className={styles.button}>
+          {confirmText}
+        </Button>
+        <Button onClick={onClose} className={styles.button} outlined>
+          {cancelText}
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #144 

## ✅ 작업 내용

여러 곳에서 반복적으로 사용되는 ConfirmModal을 구현했어요.
접근성을 고려해서 만들어봤습니다! 그 과정에서 수정되어야 할 부분도 몇 발견해서 이슈 파고 수정하려고 합니다.

사용은 이전에 제가 만들었던 `useModal()` hook과 연계해서 사용하면 됩니다.
취소(부정) 버튼은 반드시 모달을 닫는 액션 외에 아무 동작도 하지 않으므로 따로 prop을 받지 않고 내부에서 onClose prop을 전달받아 알아서 매핑합니다.

```jsx
const { open, close } = useModal(ConfirmModal);

open({
   title: "채팅방을 떠나시겠어요?",
   confirmText: "떠날래요",
   cancelText: "계속 얘기할래요",
   onConfirm: () => { 
       router.push("/chat-list");
       close();
   }
})
```

먼저 `role=dialog`를 사용해 스크린 리더가 대화 상자로 이해하도록 했어요. `dialog` 태그도 있었지만 선택하지 않은 이유는 기본적인 스타일링이 되어있는 태그여서 커스텀하려면 기본 스타일을 초기화해야 하고, 브라우저 지원이 비교적 제한적이고, DOM 메서드로 직접 열고 닫는 것을 제어하는 특성이 리액트에선 사이드이펙트로 여겨지기 때문에 구조적으로 맞지 않다고 생각했어요. 또 저희는 이미 `useModal`을 통해 마치 dialog 태그를 사용하는 것처럼 간편하게 `open`, `close`로 모달 열고닫음을 제어할 수 있습니다 😃

또 접근성을 위해 ARIA 정보를 추가했어요. 

먼저 `aria-modal=true`로 해서 dialog가 모달이고, 모달 이외(뒷배경) 영역은 스크린리더가 탐색하지 않도록 해주었습니다. 원래는 뒷배경에 직접 `aria-hidden=true`로 주어야 했지만 모달에 `aria-modal=true`를 주면 같은 효과를 낸다고 합니다.

또 `aria-labelledby`를 모달 title과 연결하여 모달의 대표 label 정보를 제공했습니다. `aria-label`과 뭐가 다른지에 대해서도 찾아봤는데, `aria-label`은 현재 화면에 내 label을 표현할 요소가 없을 때 직접 label을 입력하는 것이고, `aria-labelledby`는 현재 화면에 내 label을 표현할 요소가 있을 때 이를 연결하는 역할이라고 해요. 여기는 이 모달에 대한 정보를 `title`이 나타낸다고 생각해서 `aria-labelledby`로 연결해주었습니다!

추가적으로 트러블슈팅했던 부분인데, 처음에 뒤로가기 버튼을 누르고 모달이 떴을 때 모달에 대한 정보를 스크린리더가 읽어주지 않았어요. 알고 보니 `dialog` 태그 안 쓰고 state 변경해서 렌더링한 모달은 자동으로 focus가 가지 않기 때문이었어요. 그래서 모달이 열렸을 때 직접 focus를 모달로 이동시켜 이를 해결했어요.

```jsx
const dialogRef = useRef<HTMLDivElement>(null);

useEffect(() => {
  dialogRef.current?.focus();
}, []);
```

### 이어서 수정해야 할 부분
 
 #### BackButton 인터페이스
`BackButton`은 현재 `link`prop만 받고 있는데, 시연 영상처럼 눌렀을 때 바로 이동이 아니라 모달이 떠야 하는 경우도 있더라구요. 그래서 `BackButton`도 기본 Button attributes를 확장하도록 인터페이스를 수정해야 합니다.

#### html lang 속성
접근성 속성을 잘 설정한 후에 Mac VoiceOver로 스크린리더가 어떻게 읽는지 테스트를 해보았어요. 제가 기대했던 음성은 "대화상자, 머릿말 단계 2, 채팅방을 떠나시겠어요?" 였는데, 실제로 나오는 음성은 "대화상자, 머릿말 단계 2, Question Mark" 였어요. 이상해서 설정도 뒤져보고 했는데 원인을 못 찾아서 Cursor 찬스를 썼는데, `lang` 속성이 `en`으로 되어있어서 영어로 읽었던 것이었습니다...!!
 
그런데 이상했던 건 버튼으로 포커스를 이동하면 "떠날래요 버튼", "계속 얘기할래요 버튼" 이라고 한국어로 잘 읽었다는 것이에요. 뭘까 싶어서 찾아봤는데, 요소별로 언어 추정이 다르게 동작한다는 것을 알게 되었습니다!!!

`button`tag 같은 경우에는 `[텍스트] + "버튼"` 으로 읽는데,  저 텍스트에 적힌 문자를 기반으로 언어 감지를 해서 읽는다고 합니다.
그런데 `heading` tag는 `"머리말 단계 N" + 텍스트`로 읽는데, 텍스트를 페이지 lang 기준 음성 엔진으로 읽는다고 합니다. 굉장히 신기방기하네요...

그래서 `lang` 속성을 `ko`로 수정해야 합니다!!


## 📸 스크린샷 / GIF / Link
스크린리더가 어떻게 읽는지도 같이 담고 싶었는데 녹화에 음성이 안 들어가네요... 하단에 적힌 VoiceOver 텍스트 참고해서 보면 좋을 것 같습니다!!

뒤로가기 버튼을 누르면 모달이 열리면서 focus가 이동하고 label로 설정한 텍스트를 읽어주는 것을 확인할 수 있습니다.

https://github.com/user-attachments/assets/e567c093-2440-41a2-ac20-806f127136f4



