### PR TITLE
fix: useModal 인터페이스 수정

### DIFF
--- a/src/common/hooks/useModal.tsx
+++ b/src/common/hooks/useModal.tsx
@@ -23,7 +23,7 @@ export function useModal<P extends ModalComponentProps>(Component: React.Compone
 
   const close = useCallback(() => {
     setModals((prev) => {
-      const next = prev.filter((m) => m.id !== id);
+      const next = prev.slice(0, -1);
 
       if (next.length === 0) {
         document.body.style.overflow = "unset";
@@ -31,7 +31,7 @@ export function useModal<P extends ModalComponentProps>(Component: React.Compone
 
       return next;
     });
-  }, [id, setModals]);
+  }, [setModals]);
 
   const open = useCallback(
     (props?: Omit<P, "onClose">) => {

--- a/src/common/hooks/useModal.tsx
+++ b/src/common/hooks/useModal.tsx
@@ -1,13 +1,11 @@
-import React, { useCallback, useContext, useId, useState } from "react";
+import React, { useCallback, useContext, useId } from "react";
 import { ModalContext } from "../providers/ModalProvider";
 
 interface ModalComponentProps {
   onClose: () => void;
 }
 
-export function useModal<P extends ModalComponentProps>(
-  Component: React.ComponentType<P>
-) {
+export function useModal<P extends ModalComponentProps>(Component: React.ComponentType<P>) {
   const context = useContext(ModalContext);
 
   if (!context) throw new Error("useModal은 ModalProvider 안에서 호출해야 합니다.");
@@ -22,32 +20,28 @@ export function useModal<P extends ModalComponentProps>(
   };
 
   const id = useId();
-  const [isOpen, setIsOpen] = useState(false);
 
   const close = useCallback(() => {
-    setIsOpen(false);
     setModals((prev) => {
       const next = prev.filter((m) => m.id !== id);
-  
+
       if (next.length === 0) {
         document.body.style.overflow = "unset";
       }
-  
+
       return next;
     });
   }, [id, setModals]);
 
   const open = useCallback(
     (props?: Omit<P, "onClose">) => {
-      setIsOpen(true);
       setModals((prev) => {
         const exists = prev.some((m) => m.id === id);
-        const render = (isTop: boolean) =>  (
-            <div style={{...modalContainerStyle, pointerEvents: isTop ? "auto" : "none"}}>
-              <Component {...(props as P)} onClose={close} />
-            </div>
-          );
-
+        const render = (isTop: boolean) => (
+          <div style={{ ...modalContainerStyle, pointerEvents: isTop ? "auto" : "none" }}>
+            <Component {...(props as P)} onClose={close} />
+          </div>
+        );
 
         if (exists) {
           return prev.map((m) => (m.id === id ? { id, render } : m));
@@ -56,8 +50,8 @@ export function useModal<P extends ModalComponentProps>(
       });
       document.body.style.overflow = "hidden";
     },
-    [id, setModals, close, Component]
+    [id, setModals, close, Component],
   );
 
-  return { isOpen, open, close };
+  return { open, close };
 }

--- a/src/common/hooks/useModal.tsx
+++ b/src/common/hooks/useModal.tsx
@@ -1,57 +1,41 @@
-import React, { useCallback, useContext, useId } from "react";
+import { ReactNode, useCallback, useContext } from "react";
 import { ModalContext } from "../providers/ModalProvider";
 
-interface ModalComponentProps {
-  onClose: () => void;
-}
-
-export function useModal<P extends ModalComponentProps>(Component: React.ComponentType<P>) {
+export function useModal() {
   const context = useContext(ModalContext);
 
   if (!context) throw new Error("useModal은 ModalProvider 안에서 호출해야 합니다.");
 
   const { setModals } = context;
 
-  const modalContainerStyle: React.CSSProperties = {
-    position: "fixed",
-    top: "50%",
-    left: "50%",
-    transform: "translate(-50%, -50%)",
-  };
-
-  const id = useId();
-
-  const close = useCallback(() => {
-    setModals((prev) => {
-      const next = prev.slice(0, -1);
-
-      if (next.length === 0) {
-        document.body.style.overflow = "unset";
-      }
-
-      return next;
-    });
-  }, [setModals]);
-
   const open = useCallback(
-    (props?: Omit<P, "onClose">) => {
-      setModals((prev) => {
-        const exists = prev.some((m) => m.id === id);
-        const render = (isTop: boolean) => (
-          <div style={{ ...modalContainerStyle, pointerEvents: isTop ? "auto" : "none" }}>
-            <Component {...(props as P)} onClose={close} />
-          </div>
-        );
+    (render: (close: () => void) => ReactNode) => {
+      const id = crypto.randomUUID();
 
-        if (exists) {
-          return prev.map((m) => (m.id === id ? { id, render } : m));
-        }
-        return [...prev, { id, render }];
-      });
+      const close = () => {
+        setModals((prev) => {
+          const next = prev.filter((m) => m.id !== id);
+
+          if (next.length === 0) {
+            document.body.style.overflow = "unset";
+          }
+
+          return next;
+        });
+      };
+
+      setModals((prev) => [
+        ...prev,
+        {
+          id,
+          render: () => render(close),
+        },
+      ]);
+
       document.body.style.overflow = "hidden";
     },
-    [id, setModals, close, Component],
+    [setModals],
   );
 
-  return { open, close };
+  return { open };
 }

--- a/src/common/hooks/useModal.tsx
+++ b/src/common/hooks/useModal.tsx
@@ -9,7 +9,7 @@ export function useModal() {
   const { setModals } = context;
 
   const open = useCallback(
-    (render: (close: () => void) => ReactNode) => {
+    (render: (props: { close: () => void }) => ReactNode) => {
       const id = crypto.randomUUID();
 
       const close = () => {
@@ -28,7 +28,7 @@ export function useModal() {
         ...prev,
         {
           id,
-          render: () => render(close),
+          render: () => render({ close }),
         },
       ]);
 

--- a/src/common/providers/ModalProvider.tsx
+++ b/src/common/providers/ModalProvider.tsx
@@ -3,7 +3,7 @@ import { createContext, ReactNode, useState } from "react";
 
 type ModalItem = {
   id: string;
-  render: (isTop: boolean) => ReactNode;
+  render: () => ReactNode;
 };
 
 type ModalContextType = {
@@ -22,6 +22,13 @@ export function ModalProvider({ children }: { children: ReactNode }) {
     zIndex: Z_INDEX.BACKDROP,
   };
 
+  const modalContainerStyle: React.CSSProperties = {
+    position: "fixed",
+    top: "50%",
+    left: "50%",
+    transform: "translate(-50%, -50%)",
+  };
+
   return (
     <ModalContext.Provider value={{ setModals }}>
       {children}
@@ -30,14 +37,13 @@ export function ModalProvider({ children }: { children: ReactNode }) {
           {modals.map(({ id, render }, idx) => {
             const isTop = idx === modals.length - 1;
             return (
-            <div key={id}>
-                {render(isTop)}
+              <div key={id} style={{ ...modalContainerStyle, pointerEvents: isTop ? "auto" : "none" }}>
+                {render()}
               </div>
             );
           })}
         </div>
       )}
-      
     </ModalContext.Provider>
   );
 }


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #148 

## ✅ 작업 내용

useModal 인터페이스를 사용하기 쉽게 수정했어요.

먼저 기존에는 hook을 호출할 때 인자로 Modal 컴포넌트를 전달해서 hook 하나당 컴포넌트가 고정 매핑되는 방식이었는데, 이렇게 되면 모달이 늘어날 수록 hook 호출이 비례해서 늘어나는 점이 좋지 않다고 생각했어요.

이를 개선하기 위해 hook을 호출하면 재사용할 수 있는 open이 반환되고, open시에 모달을 렌더링하는 render 함수를 전달하는 방식으로 수정했어요. open이 여러번 호출되어도 hook 호출은 1번이라서 코드양과 가독성 측면에서 효율적입니다. 의미론적으로도 기존에는 "이 모달 사용할거야" 에서 "이 모달 열어줘"가 되므로 어색한 점이 없다고 생각했어요.

먼저 Modal이 열렸을 때 외부와의 인터랙션이 완전히 차단되므로, 외부에서 모달의 닫힘 여부를 제어할 필요가 없다고 생각했어요.
그래서 useModal은 open만 반환하도록 수정했습니다.

기존엔 useModal에서 인터랙션 차단을 담당했기 때문에(파라미터로 들어온 컴포넌트 Wrapping) useModal에서 isTop을 인자로 받는 렌더함수를 modals 상태로 저장하는 구조였는데, 조금 다른 관점으로 바라보았습니다.

인터랙션을 차단하는 것은 모달 Element 자체가 아니라 백그라운드 레이아웃입니다. useModal은 모달을 열고, 닫는 컨트롤러 역할에만 책임이 있다고 생각했고, 모달 자체의 UI, 인터랙션은 모달 컴포넌트 내부에서 담당하고, 모달 외부의 레이아웃은 Provider에서 담당하는 것이 맞다고 생각했어요.

또 어떤 모달이 최상위인지는 modals를 관리하는 Provider에서 알고 있는 정보입니다. 그래서 isTop 기반 인터랙션을 차단하는 책임을 Provider에 부여하도록 수정했습니다. 이제 useModal은 각 모달이 최상위인지, 아닌지 몰라도 됩니다. 그냥 들어온 모달을 열고 닫을 뿐입니다.

같은 의미로 `modalContainer` style은 뷰포트 기준 중앙에 모달을 위치시키는 스타일인데, 모달을 뷰포트 중앙에 위치시키는 건 레이아웃의 책임으로 바라보았습니다. 모달은 모달 자체의 UI와 기능만 담당하면 됩니다. 모달을 어느 기준 어디에 배치할지는 Provider에서 담당합니다. 물론 이는 모든 모달이 동일하게 뷰포트 중앙에 렌더링된다는 가정 하에 가능한 것이고, 모달마다 위치가 제각각이라면 각 모달에서 내가 어디에 위치하고 싶은지 알려줘야 합니다.

```jsx
// AS-IS
const modal = useModal(Modal);
const modal2 = useModal(Modal2);
const modal3 = useModal(Modal3);

modal1.open();
modal2.open();
modal3.open();

// TO-BE
const { open } = useModal();

open(Modal1)
open(Modal2)
open(Modal3)
```

open을 할 때 넘겨준 Modal에 `crypto.randomUUID`로 고유한 id값을 부여하는데, close 함수를 open 내부에서 선언해서 그 id를 클로저로 캡쳐해서 해당 id인 모달을 정확하게 닫도록 구현했어요. close는 open으로 넘어온 render 함수의 인자로 넘겨주기 때문에 render 함수는 반드시 close를 다음과 같이 인자로 받도록 넣어줘야 해요. Modal에서 onClose를 받아서 모달을 닫아야 하는 부분에 사용하면 됩니다!

```jsx
open(({close}) => <Modal onClose={close} />) 
```
